### PR TITLE
Support shell-like syntax for echo arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,7 @@ dependencies = [
  "mktemp",
  "openssl",
  "reqwest",
+ "shlex",
 ]
 
 [[package]]
@@ -721,6 +722,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 reqwest = { version = "0.11.22", features = ["blocking"] }
+shlex = "1.2.0"
 
 [dependencies.openssl]
 # This is required for reqwest to work standalone


### PR DESCRIPTION
Currently `echo "aaa"` generates `"aaa"` instead of `aaa`
This is not intended behavior.
