### PR TITLE
bump v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
 name = "gitignore-in"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "mktemp",
  "openssl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitignore-in"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Yui Kitsu <kitsuyui+github@kitsuyui.com>"]
 description = "A command line tool for managing .gitignore files with gitignore.in"


### PR DESCRIPTION
- Rename executable binary `gitignore.in` from `gitignore-in`
- Bump version 0.2.0
