### PR TITLE
Fix: clippy warnings

### DIFF
--- a/src/gi.rs
+++ b/src/gi.rs
@@ -9,37 +9,28 @@ pub fn gi_command(target: &str) -> std::io::Result<String> {
     let response = match client.get(url).send() {
         Ok(r) => r,
         Err(e) => {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!(
-                    "Failed to request to {BASE_URL}{target}: {e}",
-                    target = target
-                ),
-            ));
+            return Err(std::io::Error::other(format!(
+                "Failed to request to {BASE_URL}{target}: {e}",
+                target = target
+            )));
         }
     };
     let stdout = match response.text() {
         Ok(s) => s,
         Err(e) => {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!(
-                    "Failed to get {target} from {BASE_URL}{target}: {e}",
-                    target = target,
-                    e = e
-                ),
-            ));
+            return Err(std::io::Error::other(format!(
+                "Failed to get {target} from {BASE_URL}{target}: {e}",
+                target = target,
+                e = e
+            )));
         }
     };
     if stdout.contains("ERROR") && stdout.contains("is undefined") {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!(
-                "Failed to get {target} from {BASE_URL}{target}: {stdout}",
-                target = target,
-                stdout = stdout
-            ),
-        ));
+        return Err(std::io::Error::other(format!(
+            "Failed to get {target} from {BASE_URL}{target}: {stdout}",
+            target = target,
+            stdout = stdout
+        )));
     }
     Ok(stdout)
 }

--- a/src/gibo.rs
+++ b/src/gibo.rs
@@ -13,14 +13,11 @@ pub fn gibo_command(target: &str) -> std::io::Result<String> {
         Err(err) => return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, err)),
     };
     if stderr.contains("boilerplate not found") {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!(
-                "Failed to get {target} from gibo: {stdout}",
-                target = target,
-                stdout = stdout
-            ),
-        ));
+        return Err(std::io::Error::other(format!(
+            "Failed to get {target} from gibo: {stdout}",
+            target = target,
+            stdout = stdout
+        )));
     }
     Ok(stdout)
 }


### PR DESCRIPTION
This lint warns on calling io::Error::new(..) with a kind of io::ErrorKind::Other.
c.f. https://rust-lang.github.io/rust-clippy/rust-1.87.0/index.html#io_other_error
