### PR TITLE
Add Octocov central coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # gitignore.in
 
+![Coverage](https://raw.githubusercontent.com/gitignore-in/octocov-central/main/badges/gitignore-in/gitignore-in/coverage.svg)
+
 Website: https://www.gitignore.in/
 
 ## Motivation


### PR DESCRIPTION
## Summary
- switch the README coverage badge to the new `gitignore-in/octocov-central` badge URL
- stop referencing the removed external Codecov badge endpoint

## Testing
- not run (README-only change)
