### PR TITLE
Fix downstream dispatch workflow parsing

### DIFF
--- a/.github/workflows/prepare-downstream-release.yml
+++ b/.github/workflows/prepare-downstream-release.yml
@@ -16,7 +16,6 @@ permissions:
 jobs:
   dispatch:
     runs-on: ubuntu-latest
-    if: ${{ secrets.DOWNSTREAM_RELEASE_PAT != '' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- remove the unsupported `secrets` expression from the job-level condition
- restore valid parsing for manual and release-triggered downstream dispatches

## Testing
- attempted `workflow_dispatch` on the merged workflow and reproduced the parser failure before this fix
