### PR TITLE
Add release rehearsal workflows

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -102,11 +102,11 @@ jobs:
           mv ./$EXEC ./gitignore.in
           tar -czf ./artifacts/$NAME-$ARCH-$TAG.tar.gz ./gitignore.in
 
-      - if: startsWith(github.ref, 'refs/tags/')
+      - if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'pull_request' && startsWith(github.head_ref, 'release/'))
         name: Archive artifact
         uses: actions/upload-artifact@v7
         with:
-          name: result
+          name: result-${{ matrix.arch }}
           path: |
             ./artifacts
 
@@ -118,7 +118,8 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v8
         with:
-          name: result
+          pattern: result-*
+          merge-multiple: true
           path: ./artifacts
       - name: List
         run: find ./artifacts

--- a/.github/workflows/cratesio-publish.yml
+++ b/.github/workflows/cratesio-publish.yml
@@ -1,18 +1,27 @@
 name: publish crates
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
   release:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]
 
 jobs:
   publish:
+    if: ${{ github.event_name == 'release' || startsWith(github.head_ref, 'release/') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --release --all-features
+
+      - name: publish (release PR dry-run)
+        if: github.event_name == 'pull_request'
+        run: cargo publish --dry-run --allow-dirty
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: publish (dry-run)
         if: github.event_name == 'release' && github.event.release.prerelease

--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -1,0 +1,35 @@
+name: prepare release PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version to write into Cargo.toml (for example, 0.2.1)
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set release version
+        run: ./scripts/set-version.sh "${{ inputs.version }}"
+
+      - name: Create release pull request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          branch: release/v${{ inputs.version }}
+          delete-branch: true
+          commit-message: Release v${{ inputs.version }}
+          title: Release v${{ inputs.version }}
+          body: |
+            Prepare the source tree for release `${{ inputs.version }}`.
+
+            - update `Cargo.toml` to the target release version
+            - let release-specific PR checks validate the release candidate

--- a/.github/workflows/rehearse-downstream-on-main.yml
+++ b/.github/workflows/rehearse-downstream-on-main.yml
@@ -1,0 +1,56 @@
+name: rehearse downstream release preparation
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      released_version:
+        description: Published gitignore.in version to rehearse with (defaults to latest release tag)
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      released_version: ${{ steps.resolve.outputs.released_version }}
+      candidate_version: ${{ steps.resolve.outputs.candidate_version }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve rehearsal versions
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_RELEASED_VERSION: ${{ inputs.released_version }}
+        run: |
+          released_version="${INPUT_RELEASED_VERSION}"
+          if [ -z "${released_version}" ]; then
+            released_version="$(gh release view --json tagName --jq .tagName)"
+          fi
+          candidate_version="$(perl -ne 'print "$1\n" if /^version = "(.*)"$/' Cargo.toml | head -n1)"
+          echo "released_version=${released_version}" >> "${GITHUB_OUTPUT}"
+          echo "candidate_version=${candidate_version}" >> "${GITHUB_OUTPUT}"
+
+  dispatch:
+    runs-on: ubuntu-latest
+    needs: resolve
+    strategy:
+      fail-fast: false
+      matrix:
+        repository:
+          - gitignore-in/homebrew-gitignore-in
+          - gitignore-in/gh-action
+    steps:
+      - name: Dispatch downstream rehearsal
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ secrets.DOWNSTREAM_RELEASE_PAT }}
+          repository: ${{ matrix.repository }}
+          event-type: gitignore-in-release-published
+          client-payload: >-
+            {"version":"${{ needs.resolve.outputs.released_version }}","mode":"dry-run","candidate_version":"${{ needs.resolve.outputs.candidate_version }}","source_sha":"${{ github.sha }}","source_repository":"${{ github.repository }}"}

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${1:-}"
+if [ -z "${version}" ]; then
+  echo "usage: $0 <version>" >&2
+  exit 1
+fi
+
+perl -0pi -e 's/^version = ".*"$/version = "'"${version}"'"/m' Cargo.toml


### PR DESCRIPTION
## Summary
- add a workflow to open release PRs that update `Cargo.toml`
- rehearse downstream preparation on `main` merges with `mode=dry-run`
- treat `release/*` PRs as release-specific checks, including `cargo publish --dry-run`
- archive binary artifacts for release PRs as reviewable outputs

## Testing
- ./scripts/set-version.sh 0.2.0
- bash -n scripts/set-version.sh
- cargo test --quiet

Closes #256
Closes #257
Closes #259
