### PR TITLE
baseline-ci-permissions-001: Restrict cratesio publish workflow permissions

### DIFF
--- a/.github/workflows/cratesio-publish.yml
+++ b/.github/workflows/cratesio-publish.yml
@@ -1,5 +1,8 @@
 name: publish crates
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -9,6 +12,8 @@ on:
 
 jobs:
   publish:
+    permissions:
+      contents: read
     if: ${{ github.event_name == 'release' || startsWith(github.head_ref, 'release/') }}
     runs-on: ubuntu-latest
     steps:
@@ -18,7 +23,7 @@ jobs:
       - run: cargo build --release --all-features
 
       - name: publish (release PR dry-run)
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         run: cargo publish --dry-run --allow-dirty
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Baseline
- baseline: baseline-ci-permissions-001
- finding: cratesio publish workflow permissions are not defined

## What changed
- Add explicit `permissions` blocks at workflow and job scope in `.github/workflows/cratesio-publish.yml`.
- Keep publish dry-run path behind PR trigger, but guard it to repository-owned PRs only.

## Verification
- `cargo check --locked`
- `actionlint .github/workflows/cratesio-publish.yml` (environment: `go` unavailable in container)
