### PR TITLE
Declare workflow token permissions

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -7,6 +7,9 @@ on:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: build ${{ matrix.arch }} on ${{ matrix.os }} with ${{ matrix.gcc }}
@@ -124,6 +127,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Check


### PR DESCRIPTION
## Summary
- Add workflow-level `contents: read` permissions to the binary release and test workflows
- Grant `contents: write` only to the release deployment job that uploads GitHub Release assets

## Validation
- `git diff --check`
- `actionlint -ignore 'SC2086' .github/workflows/binary-release.yml .github/workflows/test.yml`\n\nThe ignored actionlint diagnostics are existing shell quoting warnings in the binary release scripts and are outside this permission-only change.