### PR TITLE
Encode target as URL path segment in gi_command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,7 @@ dependencies = [
  "openssl",
  "reqwest",
  "shlex",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["command-line-utilities"]
 clap = { version = "4.5.40", features = ["derive"] }
 reqwest = { version = "0.13.0", features = ["blocking"] }
 shlex = "1.3.0"
+url = "2.5"
 
 [dependencies.openssl]
 # This is required for reqwest to work standalone

--- a/src/gi.rs
+++ b/src/gi.rs
@@ -1,16 +1,26 @@
 use reqwest::blocking::Client;
+use url::Url;
 
 const BASE_URL: &str = "https://www.toptal.com/developers/gitignore/api/";
 
+fn target_url(target: &str) -> std::io::Result<Url> {
+    let mut url = Url::parse(BASE_URL)
+        .map_err(|e| std::io::Error::other(format!("Invalid BASE_URL `{BASE_URL}`: {e}")))?;
+    url.path_segments_mut()
+        .map_err(|()| std::io::Error::other(format!("BASE_URL `{BASE_URL}` is not a base URL")))?
+        .pop_if_empty()
+        .push(target);
+    Ok(url)
+}
+
 pub fn gi_command(target: &str) -> std::io::Result<String> {
-    // Request to https://www.toptal.com/developers/gitignore/api/{target}
-    let url = format!("{BASE_URL}{target}");
+    let url = target_url(target)?;
     let client = Client::new();
-    let response = match client.get(url).send() {
+    let response = match client.get(url.clone()).send() {
         Ok(r) => r,
         Err(e) => {
             return Err(std::io::Error::other(format!(
-                "Failed to request to {BASE_URL}{target}: {e}"
+                "Failed to request to {url}: {e}"
             )));
         }
     };
@@ -18,13 +28,13 @@ pub fn gi_command(target: &str) -> std::io::Result<String> {
         Ok(s) => s,
         Err(e) => {
             return Err(std::io::Error::other(format!(
-                "Failed to get {target} from {BASE_URL}{target}: {e}"
+                "Failed to get {target} from {url}: {e}"
             )));
         }
     };
     if stdout.contains("ERROR") && stdout.contains("is undefined") {
         return Err(std::io::Error::other(format!(
-            "Failed to get {target} from {BASE_URL}{target}: {stdout}"
+            "Failed to get {target} from {url}: {stdout}"
         )));
     }
     Ok(stdout)
@@ -60,6 +70,59 @@ pub fn gi_list() -> std::io::Result<Vec<String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_target_url_plain() {
+        assert_eq!(
+            target_url("Rust").unwrap().as_str(),
+            "https://www.toptal.com/developers/gitignore/api/Rust"
+        );
+    }
+
+    #[test]
+    fn test_target_url_encodes_hash() {
+        // `C#` / `F#` のように `#` を含む実在の言語名でも、fragment として
+        // 解釈されずに path segment に届くこと。
+        assert_eq!(
+            target_url("C#").unwrap().as_str(),
+            "https://www.toptal.com/developers/gitignore/api/C%23"
+        );
+    }
+
+    #[test]
+    fn test_target_url_encodes_question_mark() {
+        // `?` を含む target で query string 区切りに解釈されないこと。
+        assert_eq!(
+            target_url("templ?foo").unwrap().as_str(),
+            "https://www.toptal.com/developers/gitignore/api/templ%3Ffoo"
+        );
+    }
+
+    #[test]
+    fn test_target_url_encodes_slash() {
+        // path segment 内の `/` は escape されること (深い path を作らない)。
+        assert_eq!(
+            target_url("foo/bar").unwrap().as_str(),
+            "https://www.toptal.com/developers/gitignore/api/foo%2Fbar"
+        );
+    }
+
+    #[test]
+    fn test_target_url_encodes_space() {
+        assert_eq!(
+            target_url("hello world").unwrap().as_str(),
+            "https://www.toptal.com/developers/gitignore/api/hello%20world"
+        );
+    }
+
+    #[test]
+    fn test_target_url_preserves_plus() {
+        // `C++` のように既存テストで使われている文字は従来通り通る。
+        assert_eq!(
+            target_url("C++").unwrap().as_str(),
+            "https://www.toptal.com/developers/gitignore/api/C++"
+        );
+    }
 
     #[test]
     fn test_gi_command() {


### PR DESCRIPTION
## Summary

- The `gi` provider built request URLs via `format!("{BASE_URL}{target}")` without percent-encoding. Template names containing URL-reserved characters were silently mishandled: `C#` / `F#` had `#` dropped as a fragment, `?` was parsed as a query separator, and `/` / spaces / non-ASCII bytes reached the URL layer raw.
- Build the URL as a `url::Url` and append `target` via `path_segments_mut().push(...)` so the WHATWG path-segment percent-encoding set is applied at the boundary.
- `url` is already a transitive dep of `reqwest`; declared directly in `Cargo.toml` to document the contract and avoid relying on `reqwest::Url` being re-exported.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (36 tests pass, including new unit tests pinning the encoding for `#`, `?`, `/`, space, plus the existing `C++` shape and live `gi_command` round-trip)