### PR TITLE
use atomic writes via tempfile + rename for all file output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,6 +394,7 @@ dependencies = [
  "openssl",
  "reqwest",
  "shlex",
+ "tempfile",
  "url",
 ]
 
@@ -721,6 +738,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,6 +1073,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,6 +1354,19 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["command-line-utilities"]
 clap = { version = "4.5.40", features = ["derive"] }
 reqwest = { version = "0.13.0", features = ["blocking"] }
 shlex = "1.3.0"
+tempfile = "3"
 url = "2.5"
 
 [dependencies.openssl]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use std::{io::Read, path::Path};
+use std::{io::Read, io::Write, path::Path};
 mod build;
 mod edit;
 mod gi;
@@ -15,6 +15,14 @@ const GITIGNORE_IN_HEADER_LINES: [&str; 2] = [
     "# See https://gitignore.in/",
     "# Edit this file and run `gitignore.in` to rebuild .gitignore",
 ];
+
+fn atomic_write(path: &Path, content: impl AsRef<[u8]>) -> std::io::Result<()> {
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
+    tmp.write_all(content.as_ref())?;
+    tmp.persist(path).map_err(|e| e.error)?;
+    Ok(())
+}
 
 fn main() -> std::io::Result<()> {
     let cli = Cli::parse();
@@ -121,10 +129,8 @@ fn build_gitignore() -> std::io::Result<()> {
     }
     let statements = parse_gitignore_in_file()?;
     let result = build::build(statements)?;
-    // write to .gitignore
-    ensure_gitignore_file()?;
     let path = Path::new(".gitignore");
-    std::fs::write(path, result)?;
+    atomic_write(path, result)?;
     println!("Generated .gitignore");
     Ok(())
 }
@@ -169,23 +175,9 @@ fn bootstrap_gitignore_in_file() -> std::io::Result<BootstrapStatus> {
         return Ok(BootstrapStatus::Inferred);
     }
 
-    std::fs::File::create(path)?;
-    std::fs::write(path, gitignore_in_template_header())?;
+    atomic_write(path, gitignore_in_template_header())?;
 
     Ok(BootstrapStatus::Initialized)
-}
-
-fn ensure_gitignore_file() -> std::io::Result<()> {
-    let path = Path::new(".gitignore");
-    if let Err(e) = std::fs::metadata(path) {
-        if e.kind() == std::io::ErrorKind::NotFound {
-            match std::fs::File::create(path) {
-                Ok(_) => return Ok(()),
-                Err(_) => return Err(e),
-            }
-        }
-    }
-    Ok(())
 }
 
 fn refuse_if_gitignore_in_exists(command: &str) -> std::io::Result<()> {
@@ -207,7 +199,7 @@ fn restore_gitignore_in_file() -> std::io::Result<()> {
     let mut content = String::new();
     file.read_to_string(&mut content)?;
     let restored = add_gitignore_in_header(&restore::restore(&content));
-    std::fs::write(".gitignore.in", restored)?;
+    atomic_write(Path::new(".gitignore.in"), restored)?;
     Ok(())
 }
 
@@ -229,7 +221,7 @@ fn infer_gitignore_in_file(
             min_overlap,
         },
     )?;
-    std::fs::write(".gitignore.in", add_gitignore_in_header(&inferred))?;
+    atomic_write(Path::new(".gitignore.in"), add_gitignore_in_header(&inferred))?;
     Ok(())
 }
 
@@ -262,7 +254,7 @@ fn update_gitignore_in_file(mode: UpdateMode, templates: Vec<String>) -> std::io
             edit::remove_templates(&mut script, &templates)?;
         }
     }
-    std::fs::write(".gitignore.in", edit::render(&script))?;
+    atomic_write(Path::new(".gitignore.in"), edit::render(&script))?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- Replace all `std::fs::write` calls with an `atomic_write` helper that uses `tempfile::NamedTempFile::persist` (backed by `rename(2)`) so readers never see a partial file during concurrent writes
- Add `tempfile = "3"` dependency
- Remove the now-redundant `File::create` call in `bootstrap_gitignore_in_file` and the `ensure_gitignore_file` helper (both pre-created the target file before overwriting it)

## Test plan

- [ ] `cargo test` — all 54 tests pass
- [ ] `cargo clippy` — no warnings