### PR TITLE
Add integration tests for CLI smoke and build behavior

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -221,7 +221,10 @@ fn infer_gitignore_in_file(
             min_overlap,
         },
     )?;
-    atomic_write(Path::new(".gitignore.in"), add_gitignore_in_header(&inferred))?;
+    atomic_write(
+        Path::new(".gitignore.in"),
+        add_gitignore_in_header(&inferred),
+    )?;
     Ok(())
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,52 @@
+use std::process::Command;
+
+const BIN: &str = env!("CARGO_BIN_EXE_gitignore-in");
+
+#[test]
+fn help_flag_exits_successfully() {
+    let output = Command::new(BIN).arg("--help").output().unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Manage .gitignore files"));
+}
+
+#[test]
+fn version_flag_exits_successfully() {
+    let output = Command::new(BIN).arg("--version").output().unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("gitignore.in"));
+}
+
+#[test]
+fn build_in_empty_dir_creates_gitignore_in() {
+    let tmp = tempfile::tempdir().unwrap();
+    let output = Command::new(BIN).current_dir(tmp.path()).output().unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(tmp.path().join(".gitignore.in").exists());
+    assert!(tmp.path().join(".gitignore").exists());
+    let gitignore_in = std::fs::read_to_string(tmp.path().join(".gitignore.in")).unwrap();
+    assert!(gitignore_in.contains("# See https://gitignore.in/"));
+}
+
+#[test]
+fn build_with_existing_gitignore_in_produces_gitignore() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join(".gitignore.in"),
+        "# See https://gitignore.in/\n# Edit this file and run `gitignore.in` to rebuild .gitignore\n\necho '*.log'\n",
+    )
+    .unwrap();
+    let output = Command::new(BIN).current_dir(tmp.path()).output().unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let gitignore = std::fs::read_to_string(tmp.path().join(".gitignore")).unwrap();
+    assert!(gitignore.contains("*.log"));
+}


### PR DESCRIPTION
## Summary

- Introduce `tests/integration_test.rs` with four CLI-level integration tests
- Tests invoke the compiled binary via `std::process::Command`
- Use `tempfile::tempdir()` for isolated working directories

## Tests added

| test | what it checks |
| --- | --- |
| `help_flag_exits_successfully` | `--help` exits 0 and prints expected text |
| `version_flag_exits_successfully` | `--version` exits 0 and prints binary name |
| `build_in_empty_dir_creates_gitignore_in` | running in empty dir creates `.gitignore.in` and `.gitignore` |
| `build_with_existing_gitignore_in_produces_gitignore` | a `.gitignore.in` with `echo '*.log'` produces a `.gitignore` containing `*.log` |

## Motivation

The `tests/` directory was absent, leaving no designated place for CLI-level
end-to-end tests. These smoke tests establish the convention and add a basic
regression net for the core build flow.