### PR TITLE
Document template language semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ Supported lines are:
 - `echo <line>`: append a literal line
 - `# ...`: keep a comment in the generated output
 
+The `.gitignore.in` file is not evaluated as a shell script. Command prefixes
+are case-sensitive and match the single-space forms above (`gibo dump `,
+`gi `, and `echo `). Leading indentation, tabs between command words, or
+unknown commands are preserved when `.gitignore.in` is rewritten, but they do
+not produce generated `.gitignore` entries.
+
+`echo` lines are parsed with shell-like quoting and then normalized as command
+arguments. For example, `echo '!.gitignore'` emits `!.gitignore`, and repeated
+argument whitespace is collapsed.
+
 When you run `gitignore.in` again, `.gitignore` will be updated.
 
 If you already have a `.gitignore`, you can infer a starting `.gitignore.in` from it.
@@ -82,7 +92,7 @@ $ gitignore.in search macos rust
 ```
 
 Add templates without worrying about `gibo` vs `gi`.
-`gitignore.in` resolves names case-insensitively, prefers the provider already used in `.gitignore.in`, and rebuilds `.gitignore` after the update.
+`gitignore.in` resolves names case-insensitively, prefers the provider already used in `.gitignore.in`, falls back to `gibo` when no provider is preferred, and rebuilds `.gitignore` after the update.
 
 ```bash
 $ gitignore.in add rust macos node

--- a/src/main.rs
+++ b/src/main.rs
@@ -221,7 +221,10 @@ fn infer_gitignore_in_file(
             min_overlap,
         },
     )?;
-    atomic_write(Path::new(".gitignore.in"), add_gitignore_in_header(&inferred))?;
+    atomic_write(
+        Path::new(".gitignore.in"),
+        add_gitignore_in_header(&inferred),
+    )?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- Document that `.gitignore.in` uses a small parser instead of shell execution, including strict command prefixes and how unknown lines are handled.
- Clarify `echo` argument normalization and the `gibo` fallback when no provider is already preferred.
- Apply current `rustfmt` formatting to one existing `src/main.rs` call required by the format gate.

## Verification
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test`
- `cargo clippy -- -D warnings`
- `typos`
- `git diff --check`