### PR TITLE
Sort infer candidates alphabetically and set User-Agent on HTTP requests

### DIFF
--- a/src/gi.rs
+++ b/src/gi.rs
@@ -70,7 +70,11 @@ const USER_AGENT: &str = concat!("gitignore.in/", env!("CARGO_PKG_VERSION"));
 pub fn gi_command(target: &str) -> std::io::Result<String> {
     let url = target_url(target)?;
     let client = Client::new();
-    let response = match client.get(url.clone()).header("User-Agent", USER_AGENT).send() {
+    let response = match client
+        .get(url.clone())
+        .header("User-Agent", USER_AGENT)
+        .send()
+    {
         Ok(r) => r,
         Err(e) => {
             return Err(std::io::Error::other(format!(

--- a/src/gi.rs
+++ b/src/gi.rs
@@ -65,10 +65,12 @@ fn validate_gi_list_response(
         .collect())
 }
 
+const USER_AGENT: &str = concat!("gitignore.in/", env!("CARGO_PKG_VERSION"));
+
 pub fn gi_command(target: &str) -> std::io::Result<String> {
     let url = target_url(target)?;
     let client = Client::new();
-    let response = match client.get(url.clone()).send() {
+    let response = match client.get(url.clone()).header("User-Agent", USER_AGENT).send() {
         Ok(r) => r,
         Err(e) => {
             return Err(std::io::Error::other(format!(
@@ -91,7 +93,7 @@ pub fn gi_command(target: &str) -> std::io::Result<String> {
 pub fn gi_list() -> std::io::Result<Vec<String>> {
     let url = format!("{BASE_URL}list?format=lines");
     let client = Client::new();
-    let response = match client.get(&url).send() {
+    let response = match client.get(&url).header("User-Agent", USER_AGENT).send() {
         Ok(r) => r,
         Err(e) => {
             return Err(std::io::Error::other(format!(

--- a/src/infer.rs
+++ b/src/infer.rs
@@ -71,6 +71,7 @@ fn load_candidates(options: &InferOptions) -> std::io::Result<Vec<Candidate>> {
         });
     }
 
+    candidates.sort_by(|a, b| a.command.cmp(&b.command));
     Ok(candidates)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -221,7 +221,10 @@ fn infer_gitignore_in_file(
             min_overlap,
         },
     )?;
-    atomic_write(Path::new(".gitignore.in"), add_gitignore_in_header(&inferred))?;
+    atomic_write(
+        Path::new(".gitignore.in"),
+        add_gitignore_in_header(&inferred),
+    )?;
     Ok(())
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,52 @@
+use std::process::Command;
+
+const BIN: &str = env!("CARGO_BIN_EXE_gitignore-in");
+
+#[test]
+fn help_flag_exits_successfully() {
+    let output = Command::new(BIN).arg("--help").output().unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Manage .gitignore files"));
+}
+
+#[test]
+fn version_flag_exits_successfully() {
+    let output = Command::new(BIN).arg("--version").output().unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("gitignore.in"));
+}
+
+#[test]
+fn build_in_empty_dir_creates_gitignore_in() {
+    let tmp = tempfile::tempdir().unwrap();
+    let output = Command::new(BIN).current_dir(tmp.path()).output().unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(tmp.path().join(".gitignore.in").exists());
+    assert!(tmp.path().join(".gitignore").exists());
+    let gitignore_in = std::fs::read_to_string(tmp.path().join(".gitignore.in")).unwrap();
+    assert!(gitignore_in.contains("# See https://gitignore.in/"));
+}
+
+#[test]
+fn build_with_existing_gitignore_in_produces_gitignore() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join(".gitignore.in"),
+        "# See https://gitignore.in/\n# Edit this file and run `gitignore.in` to rebuild .gitignore\n\necho '*.log'\n",
+    )
+    .unwrap();
+    let output = Command::new(BIN).current_dir(tmp.path()).output().unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let gitignore = std::fs::read_to_string(tmp.path().join(".gitignore")).unwrap();
+    assert!(gitignore.contains("*.log"));
+}


### PR DESCRIPTION
## Summary

- Candidates returned by `gibo list` / gitignore.io were previously passed in arrival order to `choose_best_candidate`, making tie-breaking dependent on the upstream list ordering. Sorting candidates by command name before the greedy selection loop makes tie-breaking stable regardless of how upstream orders its responses.
- `User-Agent` is now set to `gitignore.in/<version>` on every HTTP request so server logs can identify the client and reqwest version upgrades no longer silently change the outgoing User-Agent string.

## Changes

- `src/infer.rs`: sort candidates by `command` name after loading them in `load_candidates`
- `src/gi.rs`: add `User-Agent: gitignore.in/<version>` header to `gi_command` and `gi_list` HTTP requests

## Test plan

- [ ] All existing unit tests pass (`cargo test`)
- [ ] `cargo clippy` reports no warnings
- [ ] Verify `infer` produces consistent output regardless of upstream list ordering