### PR TITLE
fix: restore empty echo in roundtrip

### DIFF
--- a/src/restore.rs
+++ b/src/restore.rs
@@ -35,9 +35,7 @@ pub(crate) fn restore(text: &str) -> String {
                 continue;
             }
 
-            if !section_head.is_empty() {
-                result.push(format!("echo {}", shell_quote(section_head)));
-            }
+            result.push(format!("echo {}", shell_quote(section_head)));
 
             continue;
         }
@@ -141,5 +139,26 @@ plain-entry
     fn round_trips_generated_comment_shape() {
         let restored = restore("# # original comment\n");
         assert_eq!(restored, "# original comment\n");
+    }
+
+    #[test]
+    fn restores_empty_echo() {
+        // separator + empty line comes from `echo ''` in .gitignore.in
+        let text =
+            "# -----------------------------------------------------------------------------\n\n";
+        assert_eq!(restore(text), "echo ''\n");
+    }
+
+    #[test]
+    fn round_trips_empty_echo_via_build() {
+        // build("echo ''\n") produces separator + empty line;
+        // restore should recover "echo ''\n" from that output.
+        use crate::build::build;
+        use crate::parser::parse_text;
+        let input = "echo ''\n";
+        let script = parse_text(input);
+        let built = build(script).unwrap();
+        let restored = restore(&built);
+        assert_eq!(restored, input);
     }
 }


### PR DESCRIPTION
## Summary

Fix `restore()` in `src/restore.rs` so an empty `echo` line survives a build and restore roundtrip.

Previously, `restore()` skipped an empty `section_head`, which meant a template line such as `echo ''` could be silently dropped when restoring `.gitignore.in` from generated output.

## Root Cause

`restore()` only emitted an `echo` command when `section_head` was not empty:

```rust
if !section_head.is_empty() {
    result.push(format!("echo {}", shell_quote(section_head)));
}
```

That guard treated an intentionally empty line from `echo ''` as if there was nothing to restore.

## Fix

Remove the `is_empty()` guard and always restore the section head through `shell_quote()`. For an empty string, `shell_quote("")` produces `''`, so restore now writes `echo ''` as expected.

## Tests

- Added `restores_empty_echo` to verify direct restore behavior for a separator followed by an empty line.
- Added `round_trips_empty_echo_via_build` to verify `echo ''` survives the full build and restore roundtrip.

## Test Plan

- [x] `cargo test restore`
- [x] `cargo test`
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
