### PR TITLE
fix: reject echo content that collides with section header prefixes

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -54,6 +54,12 @@ pub(crate) fn build(script: GitIgnoreIn) -> std::io::Result<String> {
                 result.push_str(&content);
             }
             GitIgnoreStatement::Echo(Echo::Content(echo)) => {
+                if echo.starts_with("# gibo dump ") || echo.starts_with("# gi ") {
+                    return Err(std::io::Error::other(format!(
+                        "echo content {echo:?} starts with a reserved section header prefix; \
+                         use a different prefix to avoid ambiguity during restore"
+                    )));
+                }
                 result.push_str(&separator());
                 result.push_str(&format!("{echo}\n"));
             }
@@ -117,5 +123,21 @@ echo hello
         let script = parse_text(text);
         let result = build(script).unwrap();
         assert_eq!(result.matches("# gibo dump C++").count(), 2);
+    }
+
+    #[test]
+    fn test_echo_with_gibo_prefix_is_rejected() {
+        let text = "echo '# gibo dump Rust'\n";
+        let script = parse_text(text);
+        let err = build(script).unwrap_err();
+        assert!(err.to_string().contains("reserved section header prefix"));
+    }
+
+    #[test]
+    fn test_echo_with_gi_prefix_is_rejected() {
+        let text = "echo '# gi Rust'\n";
+        let script = parse_text(text);
+        let err = build(script).unwrap_err();
+        assert!(err.to_string().contains("reserved section header prefix"));
     }
 }


### PR DESCRIPTION
## Summary

- Detect at build time when `echo` content in `.gitignore.in` starts with `# gibo dump ` or `# gi `
- Return a clear `io::Error` instead of silently writing output that `restore` would misparse
- Add two unit tests covering the rejected cases

## Problem

When echo content starts with `# gibo dump <X>` or `# gi <X>`, the generated `.gitignore` contains:

```
# ---separator---
# gibo dump X
```

During `restore`, this is indistinguishable from a real gibo/gi template section. The restore silently replaces the echo line with `gibo dump X` or `gi X`, corrupting the round-trip with no error or warning.

## Fix

Fail-close: `build` returns `Err` when echo content would collide. The output format is unchanged for valid inputs.

## Test plan

- [x] `cargo test` — 66 passed (including 2 new tests for the rejected cases)
- [x] `cargo clippy` — no warnings