### PR TITLE
fix: add 30s HTTP timeout and 60s subprocess timeout to prevent hangs

### DIFF
--- a/src/gi.rs
+++ b/src/gi.rs
@@ -1,6 +1,16 @@
 use reqwest::blocking::Client;
 use reqwest::StatusCode;
+use std::time::Duration;
 use url::Url;
+
+const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+
+fn build_client() -> std::io::Result<Client> {
+    Client::builder()
+        .timeout(HTTP_TIMEOUT)
+        .build()
+        .map_err(|e| std::io::Error::other(format!("Failed to build HTTP client: {e}")))
+}
 
 const BASE_URL: &str = "https://www.toptal.com/developers/gitignore/api/";
 
@@ -69,7 +79,7 @@ const USER_AGENT: &str = concat!("gitignore.in/", env!("CARGO_PKG_VERSION"));
 
 pub fn gi_command(target: &str) -> std::io::Result<String> {
     let url = target_url(target)?;
-    let client = Client::new();
+    let client = build_client()?;
     let response = match client
         .get(url.clone())
         .header("User-Agent", USER_AGENT)
@@ -104,7 +114,7 @@ pub fn gi_command(target: &str) -> std::io::Result<String> {
 
 pub fn gi_list() -> std::io::Result<Vec<String>> {
     let url = format!("{BASE_URL}list?format=lines");
-    let client = Client::new();
+    let client = build_client()?;
     let response = match client.get(&url).header("User-Agent", USER_AGENT).send() {
         Ok(r) => r,
         Err(e) => {

--- a/src/gibo.rs
+++ b/src/gibo.rs
@@ -1,4 +1,27 @@
-use std::process::ExitStatus;
+use std::process::{ExitStatus, Output};
+use std::sync::mpsc;
+use std::time::Duration;
+
+const SUBPROCESS_TIMEOUT: Duration = Duration::from_secs(60);
+
+fn run_gibo_with_timeout(args: &[&str]) -> std::io::Result<Output> {
+    let args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let result = std::process::Command::new("gibo").args(&args).output();
+        let _ = tx.send(result);
+    });
+    match rx.recv_timeout(SUBPROCESS_TIMEOUT) {
+        Ok(result) => result,
+        Err(_) => Err(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            format!(
+                "gibo timed out after {}s",
+                SUBPROCESS_TIMEOUT.as_secs()
+            ),
+        )),
+    }
+}
 
 fn validate_gibo_command_output(
     status: ExitStatus,
@@ -46,10 +69,7 @@ fn validate_gibo_list_output(
 }
 
 pub fn gibo_command(target: &str) -> std::io::Result<String> {
-    let output = std::process::Command::new("gibo")
-        .arg("dump")
-        .arg(target)
-        .output()?;
+    let output = run_gibo_with_timeout(&["dump", target])?;
 
     let stdout = match String::from_utf8(output.stdout) {
         Ok(it) => it,
@@ -63,7 +83,7 @@ pub fn gibo_command(target: &str) -> std::io::Result<String> {
 }
 
 pub fn gibo_list() -> std::io::Result<Vec<String>> {
-    let output = std::process::Command::new("gibo").arg("list").output()?;
+    let output = run_gibo_with_timeout(&["list"])?;
     let stdout = match String::from_utf8(output.stdout) {
         Ok(it) => it,
         Err(err) => return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, err)),

--- a/src/gibo.rs
+++ b/src/gibo.rs
@@ -15,10 +15,7 @@ fn run_gibo_with_timeout(args: &[&str]) -> std::io::Result<Output> {
         Ok(result) => result,
         Err(_) => Err(std::io::Error::new(
             std::io::ErrorKind::TimedOut,
-            format!(
-                "gibo timed out after {}s",
-                SUBPROCESS_TIMEOUT.as_secs()
-            ),
+            format!("gibo timed out after {}s", SUBPROCESS_TIMEOUT.as_secs()),
         )),
     }
 }


### PR DESCRIPTION
## Summary

- `gi.rs`: `Client::new()` had no timeout; replaced with `build_client()` using `Client::builder().timeout(30s)`. Both `gi_command` and `gi_list` now time out after 30 seconds on unresponsive requests.
- `gibo.rs`: `Command::output()` had no timeout; replaced with `run_gibo_with_timeout()` that runs the subprocess in a thread and waits at most 60 seconds via `mpsc::channel::recv_timeout`.

No new dependencies added. Timeout errors are returned as `std::io::ErrorKind::TimedOut`.

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo clippy` passes with no warnings
- [x] 58 unit tests pass (excluding 4 network-dependent tests)
- [x] 4 integration tests and 2 CLI tests pass