### PR TITLE
Reject multi-template provider lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ are case-sensitive and match the single-space forms above (`gibo dump `,
 `gi `, and `echo `). Leading indentation, tabs between command words, or
 unknown commands are preserved when `.gitignore.in` is rewritten, but they do
 not produce generated `.gitignore` entries.
+Template provider lines must contain exactly one template name after the prefix;
+write multiple templates as separate lines instead of `gibo dump Rust macOS`.
 
 `echo` lines are parsed with shell-like quoting and then normalized as command
 arguments. For example, `echo '!.gitignore'` emits `!.gitignore`, and repeated

--- a/src/build.rs
+++ b/src/build.rs
@@ -4,7 +4,7 @@ use crate::{
     format::{GENERATED_HEADER_LINES, SEPARATOR},
     gi::gi_command,
     gibo::gibo_command,
-    script::{Comment, Echo, Gi, Gibo, GitIgnoreIn, GitIgnoreStatement, Meaningless},
+    script::{Comment, Echo, Gi, Gibo, GitIgnoreIn, GitIgnoreStatement, Invalid, Meaningless},
 };
 
 pub(crate) fn build(script: GitIgnoreIn) -> std::io::Result<String> {
@@ -55,6 +55,12 @@ pub(crate) fn build(script: GitIgnoreIn) -> std::io::Result<String> {
                 }
                 result.push_str(&separator());
                 result.push_str(&format!("{echo}\n"));
+            }
+            GitIgnoreStatement::Invalid(Invalid::Line { reason, .. }) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    reason,
+                ));
             }
         }
     }
@@ -132,5 +138,23 @@ echo hello
         let script = parse_text(text);
         let err = build(script).unwrap_err();
         assert!(err.to_string().contains("reserved section header prefix"));
+    }
+
+    #[test]
+    fn test_multi_template_gibo_line_is_rejected() {
+        let text = "gibo dump Rust macOS\n";
+        let script = parse_text(text);
+        let err = build(script).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(err.to_string().contains("one template per line"));
+    }
+
+    #[test]
+    fn test_multi_template_gi_line_is_rejected() {
+        let text = "gi Rust macOS\n";
+        let script = parse_text(text);
+        let err = build(script).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(err.to_string().contains("one template per line"));
     }
 }

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::{
     gi::gi_list,
     gibo::gibo_list,
-    script::{Comment, Echo, Gi, Gibo, GitIgnoreIn, GitIgnoreStatement, Meaningless},
+    script::{Comment, Echo, Gi, Gibo, GitIgnoreIn, GitIgnoreStatement, Invalid, Meaningless},
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -171,6 +171,7 @@ pub(crate) fn render(script: &GitIgnoreIn) -> String {
             GitIgnoreStatement::Echo(Echo::Content(content)) => {
                 format!("echo {}", shell_word(content))
             }
+            GitIgnoreStatement::Invalid(Invalid::Line { content, .. }) => content.clone(),
         })
         .collect();
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,6 @@
-use crate::script::{Comment, Echo, Gi, Gibo, GitIgnoreIn, GitIgnoreStatement, Meaningless};
+use crate::script::{
+    Comment, Echo, Gi, Gibo, GitIgnoreIn, GitIgnoreStatement, Invalid, Meaningless,
+};
 
 pub fn parse_text(text: &str) -> GitIgnoreIn {
     let mut result = Vec::new();
@@ -11,12 +13,23 @@ pub fn parse_text(text: &str) -> GitIgnoreIn {
 }
 
 pub fn parse_line(text: &str) -> GitIgnoreStatement {
-    // TODO: support quoted string like gibo dump "C++"
     if let Some(stripped) = text.strip_prefix("gibo dump ") {
-        return GitIgnoreStatement::Gibo(Gibo::Target(remove_shell_quote(stripped)));
+        return match parse_template_target("gibo dump", stripped) {
+            Ok(target) => GitIgnoreStatement::Gibo(Gibo::Target(target)),
+            Err(reason) => GitIgnoreStatement::Invalid(Invalid::Line {
+                content: text.to_string(),
+                reason,
+            }),
+        };
     }
     if let Some(stripped) = text.strip_prefix("gi ") {
-        return GitIgnoreStatement::Gi(Gi::Target(remove_shell_quote(stripped)));
+        return match parse_template_target("gi", stripped) {
+            Ok(target) => GitIgnoreStatement::Gi(Gi::Target(target)),
+            Err(reason) => GitIgnoreStatement::Invalid(Invalid::Line {
+                content: text.to_string(),
+                reason,
+            }),
+        };
     }
     if let Some(stripped) = text.strip_prefix("echo ") {
         return GitIgnoreStatement::Echo(Echo::Content(remove_shell_quote(stripped)));
@@ -25,6 +38,22 @@ pub fn parse_line(text: &str) -> GitIgnoreStatement {
         return GitIgnoreStatement::Comment(Comment::Content(text.to_string()));
     }
     GitIgnoreStatement::Meaningless(Meaningless::Content(text.to_string()))
+}
+
+fn parse_template_target(command: &str, text: &str) -> Result<String, String> {
+    let Some(parts) = shlex::split(text) else {
+        return Err(format!("{command} has invalid shell quoting: {text:?}"));
+    };
+
+    match parts.as_slice() {
+        [target] if !target.is_empty() => Ok(target.clone()),
+        [] | [_] => Err(format!("{command} expects one non-empty template name")),
+        _ => Err(format!(
+            "{command} expects one template per line; found {} template names: {}",
+            parts.len(),
+            parts.join(", ")
+        )),
+    }
 }
 
 fn remove_shell_quote(text: &str) -> String {
@@ -66,5 +95,38 @@ echo '!.gitignore'
             ],
         };
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn template_commands_reject_multiple_unquoted_targets() {
+        assert_eq!(
+            parse_line("gibo dump Rust macOS"),
+            GitIgnoreStatement::Invalid(Invalid::Line {
+                content: "gibo dump Rust macOS".to_string(),
+                reason:
+                    "gibo dump expects one template per line; found 2 template names: Rust, macOS"
+                        .to_string(),
+            })
+        );
+        assert_eq!(
+            parse_line("gi Rust macOS"),
+            GitIgnoreStatement::Invalid(Invalid::Line {
+                content: "gi Rust macOS".to_string(),
+                reason: "gi expects one template per line; found 2 template names: Rust, macOS"
+                    .to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn template_commands_accept_quoted_single_target() {
+        assert_eq!(
+            parse_line("gibo dump \"Rust macOS\""),
+            GitIgnoreStatement::Gibo(Gibo::Target("Rust macOS".to_string()))
+        );
+        assert_eq!(
+            parse_line("gi \"Rust macOS\""),
+            GitIgnoreStatement::Gi(Gi::Target("Rust macOS".to_string()))
+        );
     }
 }

--- a/src/script.rs
+++ b/src/script.rs
@@ -10,6 +10,7 @@ pub enum GitIgnoreStatement {
     Gibo(Gibo),
     Gi(Gi),
     Echo(Echo),
+    Invalid(Invalid),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -35,4 +36,9 @@ pub enum Gi {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Echo {
     Content(String),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Invalid {
+    Line { content: String, reason: String },
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -50,3 +50,28 @@ fn build_with_existing_gitignore_in_produces_gitignore() {
     let gitignore = std::fs::read_to_string(tmp.path().join(".gitignore")).unwrap();
     assert!(gitignore.contains("*.log"));
 }
+
+#[test]
+fn build_rejects_multiple_template_names_on_one_line() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join(".gitignore.in"),
+        "# See https://gitignore.in/\n# Edit this file and run `gitignore.in` to rebuild .gitignore\n\ngibo dump Rust macOS\n",
+    )
+    .unwrap();
+
+    let output = Command::new(BIN).current_dir(tmp.path()).output().unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        output.stdout.is_empty(),
+        "stdout should stay reserved for data output: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("gibo dump expects one template per line"),
+        "stderr should explain the invalid template line: {stderr}"
+    );
+    assert!(!tmp.path().join(".gitignore").exists());
+}


### PR DESCRIPTION
## Summary

- Reject `gibo dump` and `gi` lines that contain multiple unquoted template names instead of joining them into one provider target.
- Preserve invalid provider lines when `.gitignore.in` is rewritten, while making build fail with an `InvalidInput` error that explains the one-template-per-line rule.
- Document the one-template-per-line requirement in the README and add parser/build/CLI coverage.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo check`
- `cargo build`
- `typos .`
- `go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh`
