### PR TITLE
feat: add GITIGNORE_IN_BOILERPLATES_REF env var for reproducible builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,30 @@ Exit status values are:
 
 If a `.gitignore.in` mixes `gibo` and `gi` lines, both prerequisites apply.
 
+## Reproducible builds
+
+By default, `gibo dump` fetches templates from the latest commit of the
+[boilerplates database](https://github.com/toptal/gitignore), so running
+`gitignore.in` at different times may produce different `.gitignore` output
+even from the same `.gitignore.in` input.
+
+To make a build reproducible — for example in CI — pin the boilerplates
+database to a specific commit before running `gitignore.in`:
+
+```sh
+export GITIGNORE_IN_BOILERPLATES_REF=<branch|tag|full-SHA>
+gitignore.in
+```
+
+When set, `gitignore.in` checks out the boilerplates database at the given ref
+before generating `.gitignore`. The value is resolved to a commit SHA and the
+database is left in detached HEAD state, matching the behaviour of the
+[`boilerplates_ref` input](https://github.com/gitignore-in/gh-action?tab=readme-ov-file)
+in the GitHub Action.
+
+> **Note**: this pins the `gibo` boilerplates only. Output from `gi` lines
+> still reflects the current state of `https://www.toptal.com/developers/gitignore/api/`.
+
 ## Installation
 
 ### Binary Releases

--- a/src/gibo.rs
+++ b/src/gibo.rs
@@ -4,6 +4,73 @@ use std::time::Duration;
 
 const SUBPROCESS_TIMEOUT: Duration = Duration::from_secs(60);
 
+pub fn gibo_root() -> std::io::Result<String> {
+    let output = run_gibo_with_timeout(&["root"])?;
+    let stdout = String::from_utf8(output.stdout)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    let stderr = String::from_utf8(output.stderr)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    if !output.status.success() {
+        let code = output
+            .status
+            .code()
+            .map(|c| c.to_string())
+            .unwrap_or_else(|| "<signal>".to_string());
+        return Err(std::io::Error::other(format!(
+            "gibo root failed: exit={code} stderr={stderr}"
+        )));
+    }
+    let root = stdout.trim().to_string();
+    if root.is_empty() {
+        return Err(std::io::Error::other(
+            "gibo root returned empty output; boilerplates database not initialised",
+        ));
+    }
+    Ok(root)
+}
+
+fn run_git_with_timeout(args: &[&str]) -> std::io::Result<Output> {
+    let args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let result = std::process::Command::new("git").args(&args).output();
+        let _ = tx.send(result);
+    });
+    match rx.recv_timeout(SUBPROCESS_TIMEOUT) {
+        Ok(result) => result,
+        Err(_) => Err(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            format!("git timed out after {}s", SUBPROCESS_TIMEOUT.as_secs()),
+        )),
+    }
+}
+
+pub fn pin_boilerplates(ref_spec: &str) -> std::io::Result<()> {
+    let root = gibo_root()?;
+    // Resolve to a commit SHA so we always get a detached HEAD regardless of
+    // whether ref_spec is a branch, tag, or full SHA.
+    let resolve_output =
+        run_git_with_timeout(&["-C", &root, "rev-parse", "--verify", &format!("{ref_spec}^{{commit}}")])?;
+    if !resolve_output.status.success() {
+        let stderr = String::from_utf8_lossy(&resolve_output.stderr);
+        return Err(std::io::Error::other(format!(
+            "Cannot resolve {ref_spec:?} in boilerplates at {root}: {stderr}"
+        )));
+    }
+    let sha = String::from_utf8(resolve_output.stdout)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    let sha = sha.trim();
+    let checkout_output =
+        run_git_with_timeout(&["-C", &root, "checkout", "--detach", sha])?;
+    if !checkout_output.status.success() {
+        let stderr = String::from_utf8_lossy(&checkout_output.stderr);
+        return Err(std::io::Error::other(format!(
+            "Failed to pin boilerplates to {sha} ({ref_spec:?}) in {root}: {stderr}"
+        )));
+    }
+    Ok(())
+}
+
 fn run_gibo_with_timeout(args: &[&str]) -> std::io::Result<Output> {
     let args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
     let (tx, rx) = mpsc::channel();

--- a/src/gibo.rs
+++ b/src/gibo.rs
@@ -49,8 +49,13 @@ pub fn pin_boilerplates(ref_spec: &str) -> std::io::Result<()> {
     let root = gibo_root()?;
     // Resolve to a commit SHA so we always get a detached HEAD regardless of
     // whether ref_spec is a branch, tag, or full SHA.
-    let resolve_output =
-        run_git_with_timeout(&["-C", &root, "rev-parse", "--verify", &format!("{ref_spec}^{{commit}}")])?;
+    let resolve_output = run_git_with_timeout(&[
+        "-C",
+        &root,
+        "rev-parse",
+        "--verify",
+        &format!("{ref_spec}^{{commit}}"),
+    ])?;
     if !resolve_output.status.success() {
         let stderr = String::from_utf8_lossy(&resolve_output.stderr);
         return Err(std::io::Error::other(format!(
@@ -60,8 +65,7 @@ pub fn pin_boilerplates(ref_spec: &str) -> std::io::Result<()> {
     let sha = String::from_utf8(resolve_output.stdout)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
     let sha = sha.trim();
-    let checkout_output =
-        run_git_with_timeout(&["-C", &root, "checkout", "--detach", sha])?;
+    let checkout_output = run_git_with_timeout(&["-C", &root, "checkout", "--detach", sha])?;
     if !checkout_output.status.success() {
         let stderr = String::from_utf8_lossy(&checkout_output.stderr);
         return Err(std::io::Error::other(format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,20 +112,32 @@ enum Commands {
     },
 }
 
+fn pin_boilerplates_if_requested() -> std::io::Result<()> {
+    if let Ok(ref_spec) = std::env::var("GITIGNORE_IN_BOILERPLATES_REF") {
+        if !ref_spec.is_empty() {
+            gibo::pin_boilerplates(&ref_spec)?;
+        }
+    }
+    Ok(())
+}
+
 fn run(cli: Cli) -> std::io::Result<()> {
     match cli.command {
         Some(Commands::Search { queries }) => search_templates(queries),
         Some(Commands::Add { templates }) => {
+            pin_boilerplates_if_requested()?;
             update_gitignore_in_file(UpdateMode::Add, templates)?;
             eprintln!("Updated .gitignore.in");
             build_gitignore()
         }
         Some(Commands::Remove { templates }) => {
+            pin_boilerplates_if_requested()?;
             update_gitignore_in_file(UpdateMode::Remove, templates)?;
             eprintln!("Updated .gitignore.in");
             build_gitignore()
         }
         Some(Commands::Restore) => {
+            pin_boilerplates_if_requested()?;
             refuse_if_gitignore_in_exists("restore")?;
             restore_gitignore_in_file()?;
             eprintln!("Restored .gitignore.in");
@@ -136,6 +148,7 @@ fn run(cli: Cli) -> std::io::Result<()> {
             gi,
             min_overlap,
         }) => {
+            pin_boilerplates_if_requested()?;
             refuse_if_gitignore_in_exists("infer")?;
             infer_gitignore_in_file(gibo, gi, min_overlap)?;
             eprintln!("Inferred .gitignore.in");


### PR DESCRIPTION
## Summary

`gitignore.in` calls `gibo dump` against the latest boilerplates database commit
by default, so the same `.gitignore.in` can produce different `.gitignore` output
at different points in time. The GitHub Action already exposes `boilerplates_ref`
to pin the database; this change adds an equivalent mechanism to the CLI.

## Changes

- **`src/gibo.rs`**: add `gibo_root()` (wraps `gibo root` with the existing
  subprocess timeout) and `pin_boilerplates(ref_spec)` (resolves `ref_spec` to a
  commit SHA via `git rev-parse --verify <ref>^{commit}`, then checkouts the
  boilerplates database with `git checkout --detach <sha>`; all git calls go
  through a timeout-guarded helper matching the existing `run_gibo_with_timeout`
  pattern)
- **`src/main.rs`**: add `pin_boilerplates_if_requested()` helper that reads
  `GITIGNORE_IN_BOILERPLATES_REF` and calls `pin_boilerplates` when non-empty;
  called at the start of each subcommand that uses gibo (`add`, `remove`,
  `restore`, `infer`, default build); `search` is excluded because it lists
  available templates without generating output
- **`README.md`**: new "Reproducible builds" section documenting the env var,
  accepted values (branch, tag, full SHA), detached HEAD semantics, and the
  limitation that `gi` lines still fetch from the live gitignore.io API

## Verification

- `cargo build` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test` — 73 tests pass
- `cargo fmt --all -- --check` — clean
