### PR TITLE
feat: add log/env_logger and record HTTP and subprocess latency at debug level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,6 +261,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,6 +432,8 @@ name = "gitignore-in"
 version = "0.2.1"
 dependencies = [
  "clap",
+ "env_logger",
+ "log",
  "mktemp",
  "reqwest",
  "shlex",
@@ -687,6 +721,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,6 +914,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,6 +1070,35 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 clap = { version = "4.5.40", features = ["derive"] }
+env_logger = "0.11"
+log = "0.4"
 reqwest = { version = "0.13.0", features = ["blocking"] }
 shlex = "1.3.0"
 tempfile = "3"

--- a/src/gi.rs
+++ b/src/gi.rs
@@ -1,3 +1,4 @@
+use log::debug;
 use reqwest::blocking::Client;
 use reqwest::StatusCode;
 use std::time::Duration;
@@ -80,6 +81,7 @@ const USER_AGENT: &str = concat!("gitignore.in/", env!("CARGO_PKG_VERSION"));
 pub fn gi_command(target: &str) -> std::io::Result<String> {
     let url = target_url(target)?;
     let client = build_client()?;
+    let started = std::time::Instant::now();
     let response = match client
         .get(url.clone())
         .header("User-Agent", USER_AGENT)
@@ -94,6 +96,10 @@ pub fn gi_command(target: &str) -> std::io::Result<String> {
             } else {
                 std::io::ErrorKind::Other
             };
+            debug!(
+                "HTTP GET {url} -> error ({:.0}ms): {e}",
+                started.elapsed().as_millis()
+            );
             return Err(std::io::Error::new(
                 kind,
                 format!("Failed to request to {url}: {e}"),
@@ -101,6 +107,10 @@ pub fn gi_command(target: &str) -> std::io::Result<String> {
         }
     };
     let status = response.status();
+    debug!(
+        "HTTP GET {url} -> {status} ({:.0}ms)",
+        started.elapsed().as_millis()
+    );
     let body = match response.text() {
         Ok(s) => s,
         Err(e) => {
@@ -115,6 +125,7 @@ pub fn gi_command(target: &str) -> std::io::Result<String> {
 pub fn gi_list() -> std::io::Result<Vec<String>> {
     let url = format!("{BASE_URL}list?format=lines");
     let client = build_client()?;
+    let started = std::time::Instant::now();
     let response = match client.get(&url).header("User-Agent", USER_AGENT).send() {
         Ok(r) => r,
         Err(e) => {
@@ -125,6 +136,10 @@ pub fn gi_list() -> std::io::Result<Vec<String>> {
             } else {
                 std::io::ErrorKind::Other
             };
+            debug!(
+                "HTTP GET {url} -> error ({:.0}ms): {e}",
+                started.elapsed().as_millis()
+            );
             return Err(std::io::Error::new(
                 kind,
                 format!("Failed to request to {url}: {e}"),
@@ -132,6 +147,10 @@ pub fn gi_list() -> std::io::Result<Vec<String>> {
         }
     };
     let status = response.status();
+    debug!(
+        "HTTP GET {url} -> {status} ({:.0}ms)",
+        started.elapsed().as_millis()
+    );
     let body = match response.text() {
         Ok(s) => s,
         Err(e) => {

--- a/src/gibo.rs
+++ b/src/gibo.rs
@@ -1,3 +1,4 @@
+use log::debug;
 use std::process::{ExitStatus, Output};
 use std::sync::mpsc;
 use std::time::Duration;
@@ -137,7 +138,15 @@ fn validate_gibo_list_output(
 }
 
 pub fn gibo_command(target: &str) -> std::io::Result<String> {
+    let started = std::time::Instant::now();
     let output = run_gibo_with_timeout(&["dump", target])?;
+    let elapsed_ms = started.elapsed().as_millis();
+    let code = output
+        .status
+        .code()
+        .map(|c| c.to_string())
+        .unwrap_or_else(|| "<signal>".to_string());
+    debug!("gibo dump {target} -> exit={code} ({elapsed_ms:.0}ms)");
 
     let stdout = match String::from_utf8(output.stdout) {
         Ok(it) => it,
@@ -151,7 +160,15 @@ pub fn gibo_command(target: &str) -> std::io::Result<String> {
 }
 
 pub fn gibo_list() -> std::io::Result<Vec<String>> {
+    let started = std::time::Instant::now();
     let output = run_gibo_with_timeout(&["list"])?;
+    let elapsed_ms = started.elapsed().as_millis();
+    let code = output
+        .status
+        .code()
+        .map(|c| c.to_string())
+        .unwrap_or_else(|| "<signal>".to_string());
+    debug!("gibo list -> exit={code} ({elapsed_ms:.0}ms)");
     let stdout = match String::from_utf8(output.stdout) {
         Ok(it) => it,
         Err(err) => return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, err)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand};
+use log::debug;
 use std::{
     io::{ErrorKind, Read, Write},
     path::Path,
@@ -34,6 +35,7 @@ fn atomic_write(path: &Path, content: impl AsRef<[u8]>) -> std::io::Result<()> {
 }
 
 fn main() -> ExitCode {
+    env_logger::init();
     let cli = Cli::parse();
     run_cli(cli)
 }
@@ -164,13 +166,18 @@ enum UpdateMode {
 }
 
 fn build_gitignore() -> std::io::Result<()> {
+    let started = std::time::Instant::now();
     match bootstrap_gitignore_in_file() {
-        Ok(BootstrapStatus::AlreadyPresent) => {}
+        Ok(BootstrapStatus::AlreadyPresent) => {
+            debug!("bootstrap: .gitignore.in already present");
+        }
         Ok(BootstrapStatus::Initialized) => {
             eprintln!("Initialized .gitignore.in");
+            debug!("bootstrap: initialized .gitignore.in from template");
         }
         Ok(BootstrapStatus::Inferred) => {
             eprintln!("Inferred .gitignore.in from .gitignore");
+            debug!("bootstrap: inferred .gitignore.in from existing .gitignore");
         }
         Err(e) => {
             return Err(std::io::Error::new(
@@ -180,10 +187,18 @@ fn build_gitignore() -> std::io::Result<()> {
         }
     }
     let statements = parse_gitignore_in_file()?;
+    debug!(
+        "parsed {} statements from .gitignore.in",
+        statements.content.len()
+    );
     let result = build::build(statements)?;
     let path = Path::new(".gitignore");
     atomic_write(path, result)?;
     eprintln!("Generated .gitignore");
+    debug!(
+        "build_gitignore complete ({:.0}ms)",
+        started.elapsed().as_millis()
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- Add `log` and `env_logger` crates to `Cargo.toml`
- Initialize `env_logger` in `main()` so `RUST_LOG=debug` activates all debug output
- Record HTTP GET latency (status + elapsed ms) in `gi_command` and `gi_list` via `log::debug!`
- Record subprocess latency (exit code + elapsed ms) in `gibo_command` and `gibo_list` via `log::debug!`
- Add debug logging in `build_gitignore()` for bootstrap phase, statement count, and total duration

## Motivation

The CLI had no log level control: all diagnostic output was unconditional `eprintln!`, and HTTP/subprocess latency was invisible. When a `gibo dump` call takes unexpectedly long or fails, there was no way to identify which upstream was slow without `time gitignore.in` or OS-level tracing.

With this change, `RUST_LOG=debug gitignore.in` surfaces per-call timing:

```
[DEBUG gitignore_in::gi] HTTP GET https://...gitignore/api/Rust -> 200 (143ms)
[DEBUG gitignore_in::gibo] gibo dump macOS -> exit=0 (87ms)
[DEBUG gitignore_in::main] build_gitignore complete (231ms)
```

User-facing status messages (`eprintln!` lines) are unchanged.

## Changes

- `Cargo.toml`: add `env_logger = "0.11"` and `log = "0.4"`
- `src/main.rs`: `env_logger::init()` in `main()`; `debug!` calls in `build_gitignore()`
- `src/gi.rs`: `debug!` for HTTP GET outcome and latency in `gi_command` and `gi_list`
- `src/gibo.rs`: `debug!` for subprocess outcome and latency in `gibo_command` and `gibo_list`

## Verification

- `cargo build`: pass
- `cargo test`: all tests pass (unit + integration)
- `cargo clippy`: no warnings
- `cargo fmt --check`: pass
