### PR TITLE
Add explicit size limits for external I/O reads

### DIFF
--- a/src/gi.rs
+++ b/src/gi.rs
@@ -319,9 +319,8 @@ mod tests {
     #[test]
     fn test_validate_gi_list_response_rejects_oversized_body() {
         let body = "x".repeat(MAX_RESPONSE_BYTES + 1);
-        let err =
-            validate_gi_list_response(StatusCode::OK, body, "https://example.test/list")
-                .unwrap_err();
+        let err = validate_gi_list_response(StatusCode::OK, body, "https://example.test/list")
+            .unwrap_err();
         assert!(err.to_string().contains("too large"));
     }
 

--- a/src/gi.rs
+++ b/src/gi.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use url::Url;
 
 const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_RESPONSE_BYTES: usize = 10 * 1024 * 1024;
 
 fn build_client() -> std::io::Result<Client> {
     Client::builder()
@@ -38,6 +39,12 @@ fn validate_gi_response(
             body.len()
         )));
     }
+    if body.len() > MAX_RESPONSE_BYTES {
+        return Err(std::io::Error::other(format!(
+            "Failed to get {target} from {url}: response body too large ({} bytes, max {MAX_RESPONSE_BYTES})",
+            body.len()
+        )));
+    }
     if body.is_empty() {
         return Err(std::io::Error::other(format!(
             "Failed to get {target} from {url}: empty response body"
@@ -60,6 +67,12 @@ fn validate_gi_list_response(
         return Err(std::io::Error::other(format!(
             "Failed to get list from {url}: HTTP {} (body bytes={})",
             status.as_u16(),
+            body.len()
+        )));
+    }
+    if body.len() > MAX_RESPONSE_BYTES {
+        return Err(std::io::Error::other(format!(
+            "Failed to get list from {url}: response body too large ({} bytes, max {MAX_RESPONSE_BYTES})",
             body.len()
         )));
     }
@@ -294,6 +307,22 @@ mod tests {
             validate_gi_list_response(StatusCode::OK, String::new(), "https://example.test/list")
                 .unwrap_err();
         assert!(err.to_string().contains("empty response body"));
+    }
+
+    #[test]
+    fn test_validate_gi_response_rejects_oversized_body() {
+        let body = "x".repeat(MAX_RESPONSE_BYTES + 1);
+        let err = validate_gi_response(StatusCode::OK, body, "X", &dummy_url()).unwrap_err();
+        assert!(err.to_string().contains("too large"));
+    }
+
+    #[test]
+    fn test_validate_gi_list_response_rejects_oversized_body() {
+        let body = "x".repeat(MAX_RESPONSE_BYTES + 1);
+        let err =
+            validate_gi_list_response(StatusCode::OK, body, "https://example.test/list")
+                .unwrap_err();
+        assert!(err.to_string().contains("too large"));
     }
 
     #[test]

--- a/src/gibo.rs
+++ b/src/gibo.rs
@@ -264,8 +264,7 @@ mod tests {
     #[test]
     fn test_validate_gibo_command_output_rejects_oversized_stdout() {
         let stdout = "x".repeat(MAX_SUBPROCESS_OUTPUT_BYTES + 1);
-        let err =
-            validate_gibo_command_output(make_status(0), stdout, "", "C++").unwrap_err();
+        let err = validate_gibo_command_output(make_status(0), stdout, "", "C++").unwrap_err();
         assert!(err.to_string().contains("too large"));
     }
 

--- a/src/gibo.rs
+++ b/src/gibo.rs
@@ -4,6 +4,7 @@ use std::sync::mpsc;
 use std::time::Duration;
 
 const SUBPROCESS_TIMEOUT: Duration = Duration::from_secs(60);
+const MAX_SUBPROCESS_OUTPUT_BYTES: usize = 10 * 1024 * 1024;
 
 pub fn gibo_root() -> std::io::Result<String> {
     let output = run_gibo_with_timeout(&["root"])?;
@@ -104,6 +105,12 @@ fn validate_gibo_command_output(
                 "Failed to get {target} from gibo: empty stdout (stderr={stderr})"
             )));
         }
+        if stdout.len() > MAX_SUBPROCESS_OUTPUT_BYTES {
+            return Err(std::io::Error::other(format!(
+                "Failed to get {target} from gibo: output too large ({} bytes, max {MAX_SUBPROCESS_OUTPUT_BYTES})",
+                stdout.len()
+            )));
+        }
         return Ok(stdout);
     }
     let code = status
@@ -127,6 +134,12 @@ fn validate_gibo_list_output(
             .unwrap_or_else(|| "<signal>".to_string());
         return Err(std::io::Error::other(format!(
             "Failed to list templates from gibo: exit={code} stderr={stderr}"
+        )));
+    }
+    if stdout.len() > MAX_SUBPROCESS_OUTPUT_BYTES {
+        return Err(std::io::Error::other(format!(
+            "Failed to list templates from gibo: output too large ({} bytes, max {MAX_SUBPROCESS_OUTPUT_BYTES})",
+            stdout.len()
         )));
     }
     Ok(stdout
@@ -246,6 +259,21 @@ mod tests {
             validate_gibo_list_output(make_status(127), String::new(), "gibo: command failed")
                 .unwrap_err();
         assert!(err.to_string().contains("exit=127"));
+    }
+
+    #[test]
+    fn test_validate_gibo_command_output_rejects_oversized_stdout() {
+        let stdout = "x".repeat(MAX_SUBPROCESS_OUTPUT_BYTES + 1);
+        let err =
+            validate_gibo_command_output(make_status(0), stdout, "", "C++").unwrap_err();
+        assert!(err.to_string().contains("too large"));
+    }
+
+    #[test]
+    fn test_validate_gibo_list_output_rejects_oversized_stdout() {
+        let stdout = "x".repeat(MAX_SUBPROCESS_OUTPUT_BYTES + 1);
+        let err = validate_gibo_list_output(make_status(0), stdout, "").unwrap_err();
+        assert!(err.to_string().contains("too large"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -353,7 +353,10 @@ fn parse_path(path: &Path) -> std::io::Result<script::GitIgnoreIn> {
     if content.len() as u64 > MAX_FILE_BYTES {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
-            format!("{} exceeds size limit ({MAX_FILE_BYTES} bytes)", path.display()),
+            format!(
+                "{} exceeds size limit ({MAX_FILE_BYTES} bytes)",
+                path.display()
+            ),
         ));
     }
     let result = parser::parse_text(&content);

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ const EXIT_GENERAL_ERROR: u8 = 1;
 const EXIT_USAGE_ERROR: u8 = 2;
 const EXIT_PERMISSION_DENIED: u8 = 13;
 const EXIT_TEMPORARY_FAILURE: u8 = 75;
+const MAX_FILE_BYTES: u64 = 1024 * 1024;
 
 fn atomic_write(path: &Path, content: impl AsRef<[u8]>) -> std::io::Result<()> {
     let dir = path.parent().unwrap_or_else(|| Path::new("."));
@@ -262,9 +263,15 @@ fn refuse_if_gitignore_in_exists(command: &str) -> std::io::Result<()> {
 
 fn restore_gitignore_in_file() -> std::io::Result<()> {
     let path = std::path::Path::new(".gitignore");
-    let mut file = std::fs::File::open(path)?;
+    let file = std::fs::File::open(path)?;
     let mut content = String::new();
-    file.read_to_string(&mut content)?;
+    file.take(MAX_FILE_BYTES + 1).read_to_string(&mut content)?;
+    if content.len() as u64 > MAX_FILE_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(".gitignore exceeds size limit ({MAX_FILE_BYTES} bytes)"),
+        ));
+    }
     let restored = add_gitignore_in_header(&restore::restore(&content));
     atomic_write(Path::new(".gitignore.in"), restored)?;
     Ok(())
@@ -276,9 +283,15 @@ fn infer_gitignore_in_file(
     min_overlap: usize,
 ) -> std::io::Result<()> {
     let path = std::path::Path::new(".gitignore");
-    let mut file = std::fs::File::open(path)?;
+    let file = std::fs::File::open(path)?;
     let mut content = String::new();
-    file.read_to_string(&mut content)?;
+    file.take(MAX_FILE_BYTES + 1).read_to_string(&mut content)?;
+    if content.len() as u64 > MAX_FILE_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(".gitignore exceeds size limit ({MAX_FILE_BYTES} bytes)"),
+        ));
+    }
 
     let inferred = infer::infer_with_options(
         &content,
@@ -334,9 +347,15 @@ fn parse_gitignore_in_file() -> std::io::Result<script::GitIgnoreIn> {
 }
 
 fn parse_path(path: &Path) -> std::io::Result<script::GitIgnoreIn> {
-    let mut file = std::fs::File::open(path)?;
+    let file = std::fs::File::open(path)?;
     let mut content = String::new();
-    file.read_to_string(&mut content)?;
+    file.take(MAX_FILE_BYTES + 1).read_to_string(&mut content)?;
+    if content.len() as u64 > MAX_FILE_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("{} exceeds size limit ({MAX_FILE_BYTES} bytes)", path.display()),
+        ));
+    }
     let result = parser::parse_text(&content);
     Ok(result)
 }
@@ -539,6 +558,17 @@ mod tests {
     fn add_gitignore_in_header_keeps_existing_header() {
         let content = "# See https://gitignore.in/\n# Edit this file and run `gitignore.in` to rebuild .gitignore\n";
         assert_eq!(add_gitignore_in_header(content), content);
+    }
+
+    #[test]
+    fn parse_path_rejects_oversized_file() {
+        let temp_dir = Temp::new_dir().expect("failed to create temp dir");
+        let path = temp_dir.as_path().join("huge.in");
+        let oversized = "x".repeat((MAX_FILE_BYTES + 1) as usize);
+        std::fs::write(&path, oversized).expect("failed to write oversized file");
+        let err = parse_path(&path).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("exceeds size limit"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add explicit upper-bound guards before processing content read from external
sources (HTTP responses, subprocess stdout, local files):

- **`src/gi.rs`**: `validate_gi_response` and `validate_gi_list_response` now
  reject any body exceeding `MAX_RESPONSE_BYTES` (10 MB) with a clear error
  message before passing content downstream.
- **`src/gibo.rs`**: `validate_gibo_command_output` and
  `validate_gibo_list_output` reject subprocess stdout over
  `MAX_SUBPROCESS_OUTPUT_BYTES` (10 MB).
- **`src/main.rs`**: `parse_path`, `restore_gitignore_in_file`, and
  `infer_gitignore_in_file` now use `Read::take(MAX_FILE_BYTES + 1)` to cap
  file reads at 1 MB before allocating the full `String` buffer.

## Motivation

`.gitignore` templates and gitignore.io / gibo responses are normally a few
KB. Without an explicit cap, a malformed upstream response or an accidental
path to a large file would expand heap without bound before any downstream
validation could fire. The take-based approach for file reads also limits
allocation before the data lands in a `String`.

## Trade-offs

- The 10 MB response limit and 1 MB file limit are generous for all expected
  inputs; adjusting them requires a code change.
- HTTP responses are still read fully before the size check applies (reqwest
  blocking API). A streaming cap would require a more invasive refactor.

## Test plan

- [ ] `cargo test` passes (74 unit + integration tests, plus 6 new rejection
  tests covering each guard path)
- [ ] `cargo clippy -- -D warnings` passes
