### PR TITLE
Add concurrency controls to push/pull_request workflows

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -7,6 +7,10 @@ on:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/cratesio-publish.yml
+++ b/.github/workflows/cratesio-publish.yml
@@ -10,6 +10,10 @@ on:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   publish:
     permissions:

--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/rehearse-downstream-on-main.yml
+++ b/.github/workflows/rehearse-downstream-on-main.yml
@@ -10,6 +10,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary

Five `push`/`pull_request`-triggered workflows had no top-level `concurrency`
group, so stale CI runs from previous commits could accumulate and waste
runner minutes.

## Changes

Added a `concurrency:` block to each affected workflow:

| Workflow | Trigger | `cancel-in-progress` |
|---|---|---|
| `test.yml` | `pull_request` | `true` |
| `octocov.yml` | `pull_request`, `push` | `true` |
| `binary-release.yml` | `pull_request`, `release` | `${{ github.event_name == 'pull_request' }}` |
| `cratesio-publish.yml` | `pull_request`, `release` | `${{ github.event_name == 'pull_request' }}` |
| `rehearse-downstream-on-main.yml` | `push`, `workflow_dispatch` | `true` |

The `group` is `${{ github.workflow }}-${{ github.ref }}` in all cases.
Release-triggered runs in `binary-release.yml` and `cratesio-publish.yml`
are **not** cancelled (`cancel-in-progress` evaluates to `false` for
`release` events) to avoid interrupting binary uploads and crates.io
publishes.

## Verification

No Rust source changes; `cargo clippy` and `cargo test` are unaffected.
Concurrency behaviour is verified at runtime by GitHub Actions.