### PR TITLE
Remove misleading codeToTestRatio from octocov config

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -2,11 +2,6 @@
 coverage:
   paths:
     - coverage.lcov
-codeToTestRatio:
-  code:
-    - "src/**/*.rs"
-  test:
-    - "tests/**/*.rs"
 testExecutionTime:
   if: true
 diff:


### PR DESCRIPTION
## Summary

The `codeToTestRatio` section in `.octocov.yml` was configured with:

- `code`: `src/**/*.rs`
- `test`: `tests/**/*.rs`

This glob pair is misleading for this project because Rust tests live inline in `src/*.rs` as `#[cfg(test)]` modules, not in a separate `tests/` directory. As a result, the test-side file count is either zero or very small, producing an artificially low (and inaccurate) code-to-test ratio in every CI run.

The `coverage` section — powered by `cargo llvm-cov --lcov` — already captures test effectiveness correctly, including inline tests. There is no need to supplement it with a file-path-based ratio that cannot see inline test modules.

## Change

Removes the `codeToTestRatio` block from `.octocov.yml` to eliminate the noise this metric injects into CI comments and PR reviews.

## Impact

- CI comments will no longer show a misleading code:test ratio.
- Coverage reporting via `cargo llvm-cov` is unaffected.
