### PR TITLE
Clarify infer target selection

### DIFF
--- a/src/infer.rs
+++ b/src/infer.rs
@@ -12,18 +12,24 @@ pub(crate) struct Candidate {
     pub(crate) lines: BTreeSet<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TemplateTargets {
+    All,
+    Explicit(Vec<String>),
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct InferOptions {
-    pub(crate) gibo_targets: Vec<String>,
-    pub(crate) gi_targets: Vec<String>,
+    pub(crate) gibo_targets: TemplateTargets,
+    pub(crate) gi_targets: TemplateTargets,
     pub(crate) min_overlap: usize,
 }
 
 impl Default for InferOptions {
     fn default() -> Self {
         Self {
-            gibo_targets: Vec::new(),
-            gi_targets: Vec::new(),
+            gibo_targets: TemplateTargets::All,
+            gi_targets: TemplateTargets::All,
             min_overlap: 2,
         }
     }
@@ -44,15 +50,13 @@ pub(crate) fn infer_with_options(text: &str, options: &InferOptions) -> std::io:
 
 fn load_candidates(options: &InferOptions) -> std::io::Result<Vec<Candidate>> {
     let mut candidates = Vec::new();
-    let gibo_targets = if options.gibo_targets.is_empty() && options.gi_targets.is_empty() {
-        gibo_list()?
-    } else {
-        options.gibo_targets.clone()
+    let gibo_targets = match &options.gibo_targets {
+        TemplateTargets::All => gibo_list()?,
+        TemplateTargets::Explicit(targets) => targets.clone(),
     };
-    let gi_targets = if options.gi_targets.is_empty() && options.gibo_targets.is_empty() {
-        gi_list()?
-    } else {
-        options.gi_targets.clone()
+    let gi_targets = match &options.gi_targets {
+        TemplateTargets::All => gi_list()?,
+        TemplateTargets::Explicit(targets) => targets.clone(),
     };
 
     for target in &gibo_targets {
@@ -217,6 +221,14 @@ mod tests {
             command: command.to_string(),
             lines: lines.iter().map(|line| line.to_string()).collect(),
         }
+    }
+
+    #[test]
+    fn default_options_select_all_provider_targets_explicitly() {
+        let options = InferOptions::default();
+
+        assert_eq!(options.gibo_targets, TemplateTargets::All);
+        assert_eq!(options.gi_targets, TemplateTargets::All);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -293,6 +293,7 @@ fn infer_gitignore_in_file(
         ));
     }
 
+    let (gibo_targets, gi_targets) = infer_target_selection(gibo_targets, gi_targets);
     let inferred = infer::infer_with_options(
         &content,
         &infer::InferOptions {
@@ -306,6 +307,20 @@ fn infer_gitignore_in_file(
         add_gitignore_in_header(&inferred),
     )?;
     Ok(())
+}
+
+fn infer_target_selection(
+    gibo_targets: Vec<String>,
+    gi_targets: Vec<String>,
+) -> (infer::TemplateTargets, infer::TemplateTargets) {
+    if gibo_targets.is_empty() && gi_targets.is_empty() {
+        (infer::TemplateTargets::All, infer::TemplateTargets::All)
+    } else {
+        (
+            infer::TemplateTargets::Explicit(gibo_targets),
+            infer::TemplateTargets::Explicit(gi_targets),
+        )
+    }
 }
 
 fn update_gitignore_in_file(mode: UpdateMode, templates: Vec<String>) -> std::io::Result<()> {
@@ -521,6 +536,26 @@ mod tests {
             }
             _ => unreachable!(),
         }
+    }
+
+    #[test]
+    fn infer_targets_select_all_when_both_providers_are_omitted() {
+        let (gibo_targets, gi_targets) = infer_target_selection(Vec::new(), Vec::new());
+
+        assert_eq!(gibo_targets, infer::TemplateTargets::All);
+        assert_eq!(gi_targets, infer::TemplateTargets::All);
+    }
+
+    #[test]
+    fn infer_targets_keep_empty_provider_explicit_when_other_provider_is_set() {
+        let (gibo_targets, gi_targets) =
+            infer_target_selection(Vec::new(), vec!["node".to_string()]);
+
+        assert_eq!(gibo_targets, infer::TemplateTargets::Explicit(Vec::new()));
+        assert_eq!(
+            gi_targets,
+            infer::TemplateTargets::Explicit(vec!["node".to_string()])
+        );
     }
 
     #[test]


### PR DESCRIPTION
Summary
- Clarify infer provider target selection with an explicit All vs Explicit state.
- Keep CLI behavior compatible: omitting both provider flags loads all providers; specifying one provider leaves the other explicitly empty.
- Add tests for the default all-provider path and one-provider-specified behavior.

Verification
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test`
- `cargo clippy -- -D warnings`
- `git diff --check`
- `typos`