### PR TITLE
fix: map HTTP 5xx to EXIT_TEMPORARY_FAILURE and oversized input to EXIT_USAGE_ERROR

### DIFF
--- a/src/gi.rs
+++ b/src/gi.rs
@@ -33,11 +33,19 @@ fn validate_gi_response(
     url: &Url,
 ) -> std::io::Result<String> {
     if !status.is_success() {
-        return Err(std::io::Error::other(format!(
-            "Failed to get {target} from {url}: HTTP {} (body bytes={})",
-            status.as_u16(),
-            body.len()
-        )));
+        let kind = if status.is_server_error() {
+            std::io::ErrorKind::ConnectionAborted
+        } else {
+            std::io::ErrorKind::Other
+        };
+        return Err(std::io::Error::new(
+            kind,
+            format!(
+                "Failed to get {target} from {url}: HTTP {} (body bytes={})",
+                status.as_u16(),
+                body.len()
+            ),
+        ));
     }
     if body.len() > MAX_RESPONSE_BYTES {
         return Err(std::io::Error::other(format!(
@@ -64,11 +72,19 @@ fn validate_gi_list_response(
     url: &str,
 ) -> std::io::Result<Vec<String>> {
     if !status.is_success() {
-        return Err(std::io::Error::other(format!(
-            "Failed to get list from {url}: HTTP {} (body bytes={})",
-            status.as_u16(),
-            body.len()
-        )));
+        let kind = if status.is_server_error() {
+            std::io::ErrorKind::ConnectionAborted
+        } else {
+            std::io::ErrorKind::Other
+        };
+        return Err(std::io::Error::new(
+            kind,
+            format!(
+                "Failed to get list from {url}: HTTP {} (body bytes={})",
+                status.as_u16(),
+                body.len()
+            ),
+        ));
     }
     if body.len() > MAX_RESPONSE_BYTES {
         return Err(std::io::Error::other(format!(
@@ -253,6 +269,7 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.to_string().contains("HTTP 500"));
+        assert_eq!(err.kind(), std::io::ErrorKind::ConnectionAborted);
     }
 
     #[test]
@@ -261,6 +278,20 @@ mod tests {
         let err = validate_gi_response(StatusCode::SERVICE_UNAVAILABLE, html, "X", &dummy_url())
             .unwrap_err();
         assert!(err.to_string().contains("HTTP 503"));
+        assert_eq!(err.kind(), std::io::ErrorKind::ConnectionAborted);
+    }
+
+    #[test]
+    fn test_validate_gi_response_rejects_4xx_with_other_kind() {
+        let err = validate_gi_response(
+            StatusCode::NOT_FOUND,
+            "Not found".to_string(),
+            "X",
+            &dummy_url(),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("HTTP 404"));
+        assert_eq!(err.kind(), std::io::ErrorKind::Other);
     }
 
     #[test]
@@ -299,6 +330,19 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.to_string().contains("HTTP 502"));
+        assert_eq!(err.kind(), std::io::ErrorKind::ConnectionAborted);
+    }
+
+    #[test]
+    fn test_validate_gi_list_response_rejects_4xx_with_other_kind() {
+        let err = validate_gi_list_response(
+            StatusCode::NOT_FOUND,
+            "Not found".to_string(),
+            "https://example.test/list",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("HTTP 404"));
+        assert_eq!(err.kind(), std::io::ErrorKind::Other);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -268,7 +268,7 @@ fn restore_gitignore_in_file() -> std::io::Result<()> {
     file.take(MAX_FILE_BYTES + 1).read_to_string(&mut content)?;
     if content.len() as u64 > MAX_FILE_BYTES {
         return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
+            std::io::ErrorKind::InvalidInput,
             format!(".gitignore exceeds size limit ({MAX_FILE_BYTES} bytes)"),
         ));
     }
@@ -288,7 +288,7 @@ fn infer_gitignore_in_file(
     file.take(MAX_FILE_BYTES + 1).read_to_string(&mut content)?;
     if content.len() as u64 > MAX_FILE_BYTES {
         return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
+            std::io::ErrorKind::InvalidInput,
             format!(".gitignore exceeds size limit ({MAX_FILE_BYTES} bytes)"),
         ));
     }
@@ -352,7 +352,7 @@ fn parse_path(path: &Path) -> std::io::Result<script::GitIgnoreIn> {
     file.take(MAX_FILE_BYTES + 1).read_to_string(&mut content)?;
     if content.len() as u64 > MAX_FILE_BYTES {
         return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
+            std::io::ErrorKind::InvalidInput,
             format!(
                 "{} exceeds size limit ({MAX_FILE_BYTES} bytes)",
                 path.display()
@@ -570,8 +570,18 @@ mod tests {
         let oversized = "x".repeat((MAX_FILE_BYTES + 1) as usize);
         std::fs::write(&path, oversized).expect("failed to write oversized file");
         let err = parse_path(&path).unwrap_err();
-        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
         assert!(err.to_string().contains("exceeds size limit"));
+    }
+
+    #[test]
+    fn run_cli_maps_oversized_input_to_usage_exit_code() {
+        let temp_dir = Temp::new_dir().expect("failed to create temp dir");
+        let _guard = CwdGuard::new(temp_dir.as_path());
+        let oversized = "x".repeat((MAX_FILE_BYTES + 1) as usize);
+        std::fs::write(".gitignore.in", oversized).expect("failed to write .gitignore.in");
+        let exit_code = run_cli(Cli { command: None });
+        assert_eq!(exit_code, ExitCode::from(EXIT_USAGE_ERROR));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The exit code mapping for two error categories did not match the documented exit code table in the README.

**HTTP 5xx (server errors) → `EXIT_TEMPORARY_FAILURE` (75)**

`validate_gi_response` and `validate_gi_list_response` used `Error::other()` for all non-2xx responses, which produces `ErrorKind::Other` and maps to `EXIT_GENERAL_ERROR` (1). Callers that implement retry-on-75 logic (following the EX_TEMPFAIL convention) will never trigger a retry on HTTP 503/502, even though those are transient server-side failures.

The fix: when the HTTP status is a server error (5xx), use `ErrorKind::ConnectionAborted` instead of `Other`. `ConnectionAborted` is already in the `EXIT_TEMPORARY_FAILURE` branch of `exit_code_for_error`. HTTP 4xx (client errors) retain `ErrorKind::Other` → `EXIT_GENERAL_ERROR`, as those are non-transient.

**Oversized `.gitignore.in` → `EXIT_USAGE_ERROR` (2)**

`parse_path`, `restore_gitignore_in_file`, and `infer_gitignore_in_file` returned `ErrorKind::InvalidData` for files exceeding the size limit. `InvalidData` falls through to `EXIT_GENERAL_ERROR` (1). Passing an oversized file is an interface contract violation, so `ErrorKind::InvalidInput` → `EXIT_USAGE_ERROR` (2) is the correct classification.

## Changes

- `src/gi.rs`: Split HTTP non-2xx handling to use `ErrorKind::ConnectionAborted` for 5xx, `ErrorKind::Other` for 4xx. Added tests for both branches.
- `src/main.rs`: Changed `ErrorKind::InvalidData` → `ErrorKind::InvalidInput` in all three size-limit checks. Updated `parse_path_rejects_oversized_file` test. Added `run_cli_maps_oversized_input_to_usage_exit_code` test.

## Verification

- `cargo fmt` — no diff
- `cargo clippy -- -D warnings` — clean
- `cargo test` — 80 unit tests pass, 2 CLI output tests pass, 5 integration tests pass