### PR TITLE
ci: verify release tag matches Cargo version

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -86,6 +86,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Verify release version
+        if: github.event_name == 'release' || startsWith(github.head_ref, 'release/')
+        env:
+          RELEASE_REF: ${{ github.event_name == 'release' && github.event.release.tag_name || github.head_ref }}
+        run: ./scripts/check-release-version.sh "${RELEASE_REF}"
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.arch }}
@@ -94,30 +99,33 @@ jobs:
           key: ${{ matrix.os }}-${{ matrix.arch }}
       - name: Build target
         run: |
-          if [[ $OS =~ ^.*ubuntu.*$ ]]; then
-            rustup target add $ARCH
-            sudo apt-get update && sudo apt-get install -y $PACKAGE
-            TARGET="$ARCH" CFLAGS="$CFLAGS" CC=$GCC cargo build --release --verbose --target $ARCH
-          elif [[ $OS =~ ^.*macos.*$ ]]; then
-            MACOSX_DEPLOYMENT_TARGET="${{ matrix.deployment_target }}" cargo build --release --verbose --target $ARCH
+          if [[ "${OS}" =~ ^.*ubuntu.*$ ]]; then
+            rustup target add "${ARCH}"
+            if [ -n "${PACKAGE:-}" ]; then
+              # shellcheck disable=SC2086
+              sudo apt-get update && sudo apt-get install -y ${PACKAGE}
+            fi
+            TARGET="${ARCH}" CFLAGS="${CFLAGS}" CC="${GCC}" cargo build --release --verbose --target "${ARCH}"
+          elif [[ "${OS}" =~ ^.*macos.*$ ]]; then
+            MACOSX_DEPLOYMENT_TARGET="${{ matrix.deployment_target }}" cargo build --release --verbose --target "${ARCH}"
           fi
 
       - name: Compress
         run: |
           mkdir -p ./artifacts
-          if [[ $ARCH =~ ^.*windows.*$ ]]; then
-              EXEC=$NAME.exe
+          if [[ "${ARCH}" =~ ^.*windows.*$ ]]; then
+              EXEC="${NAME}.exe"
           else
-              EXEC=$NAME
+              EXEC="${NAME}"
           fi
           if [[ $GITHUB_REF_TYPE =~ ^tag$ ]]; then
-            TAG=$GITHUB_REF_NAME
+            TAG="${GITHUB_REF_NAME}"
           else
-            TAG=$GITHUB_SHA
+            TAG="${GITHUB_SHA}"
           fi
-          mv ./target/$ARCH/release/$EXEC ./$EXEC
-          mv ./$EXEC ./gitignore.in
-          tar -czf ./artifacts/$NAME-$ARCH-$TAG.tar.gz ./gitignore.in
+          mv "./target/${ARCH}/release/${EXEC}" "./${EXEC}"
+          mv "./${EXEC}" ./gitignore.in
+          tar -czf "./artifacts/${NAME}-${ARCH}-${TAG}.tar.gz" ./gitignore.in
 
       - if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'pull_request' && startsWith(github.head_ref, 'release/'))
         name: Archive artifact

--- a/.github/workflows/cratesio-publish.yml
+++ b/.github/workflows/cratesio-publish.yml
@@ -22,6 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Verify release version
+        env:
+          RELEASE_REF: ${{ github.event_name == 'release' && github.event.release.tag_name || github.head_ref }}
+        run: ./scripts/check-release-version.sh "${RELEASE_REF}"
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo build --release --all-features

--- a/scripts/check-release-version.sh
+++ b/scripts/check-release-version.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+release_ref="${1:-}"
+if [ -z "${release_ref}" ]; then
+	echo "usage: $0 <release-tag-or-release-branch>" >&2
+	exit 2
+fi
+
+case "${release_ref}" in
+refs/tags/v* | v* | release/v*)
+	release_version="${release_ref##*/}"
+	release_version="${release_version#v}"
+	;;
+*)
+	echo "release ref must be v<version> or release/v<version>: ${release_ref}" >&2
+	exit 1
+	;;
+esac
+
+cargo_version="$(
+	perl -ne 'if (/^version = "([^"]+)"$/) { print "$1\n"; exit }' Cargo.toml
+)"
+
+if [ -z "${cargo_version}" ]; then
+	echo "failed to read package version from Cargo.toml" >&2
+	exit 1
+fi
+
+if [ "${release_version}" != "${cargo_version}" ]; then
+	echo "release version ${release_version} does not match Cargo.toml version ${cargo_version}" >&2
+	exit 1
+fi
+
+echo "release version matches Cargo.toml: ${cargo_version}"


### PR DESCRIPTION
## Summary
- Verify that release tags and release branches match the Cargo package version before release workflows proceed.
- Harden the binary release workflow shell logic for safer quoting and clearer target handling.

## Verification
- `./scripts/check-release-version.sh v0.2.1`
- `./scripts/check-release-version.sh release/v0.2.1`
- `./scripts/check-release-version.sh refs/tags/v0.2.1`
- `./scripts/check-release-version.sh v9.9.9` fails as expected
- `go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh`
- `actionlint`
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo build`
- `cargo build --release --all-features`
- `cargo publish --dry-run --allow-dirty`
