### PR TITLE
docs(infer): document default all-provider fetch in --help

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,9 @@ enum Commands {
     },
     /// Restore .gitignore.in from a generated .gitignore and rebuild .gitignore
     Restore,
-    /// Infer .gitignore.in from an existing .gitignore and rebuild .gitignore
+    /// Infer .gitignore.in from an existing .gitignore and rebuild .gitignore.
+    /// If both --gibo and --gi are omitted, all templates from both providers
+    /// are checked (may trigger many network requests).
     Infer {
         /// Comma-separated gibo targets to consider
         #[arg(long, value_delimiter = ',')]


### PR DESCRIPTION
## Summary

The `infer` subcommand's `--help` output did not mention that omitting
both `--gibo` and `--gi` causes all templates from both gibo and
gitignore.io to be checked.

The README (under *"This infer mode is heuristic."*) already states:
> If you omit both `--gibo` and `--gi`, it checks all available templates
> from both providers.

However, `gitignore.in infer --help` showed no indication of this
behaviour. A user running `infer` without flags would encounter
potentially hundreds of network requests (gibo and gitignore.io template
listings) with no prior warning.

## Change

`src/main.rs`: extend the `Infer` variant's doc comment with a two-line
note:
```
If both --gibo and --gi are omitted, all templates from both providers
are checked (may trigger many network requests).
```

This text surfaces in `gitignore.in infer --help` via clap's automatic
help generation.

## Verification

- `cargo fmt --all`: no changes
- `cargo clippy --all-targets --all-features -- -D warnings`: 0 findings
- `cargo test`: 7/7 pass
- `gitignore.in infer --help` confirmed to show the new text

## Trade-offs

The subcommand description becomes three lines instead of one. No
behaviour change; no API change.
