### PR TITLE
ci: add concurrency to remaining workflows

### DIFF
--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -5,6 +5,10 @@ on:
     # daily at 00:00
     - cron: '0 0 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/happy.yml
+++ b/.github/workflows/happy.yml
@@ -2,6 +2,10 @@ name: happy-commit
 on:
   - pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/prepare-downstream-release.yml
+++ b/.github/workflows/prepare-downstream-release.yml
@@ -10,6 +10,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/prepare-next-development-pr.yml
+++ b/.github/workflows/prepare-next-development-pr.yml
@@ -10,6 +10,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -8,6 +8,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,6 +1,11 @@
 name: Spellcheck
 on:
   - pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
Summary:
- add top-level concurrency groups to the remaining workflows without one
- cancel stale in-progress runs for scheduled, pull request, release-prep, and manual workflows
- reuse the existing `${{ github.workflow }}-${{ github.ref }}` grouping pattern

Tests:
- git diff --check
- actionlint .github/workflows/gitignore-in.yml .github/workflows/happy.yml .github/workflows/prepare-downstream-release.yml .github/workflows/prepare-next-development-pr.yml .github/workflows/prepare-release-pr.yml .github/workflows/spellcheck.yml

Note:
- Full repository actionlint still reports pre-existing shellcheck SC2086 warnings in .github/workflows/binary-release.yml, which this PR does not touch.
