### PR TITLE
fix: cap subprocess and HTTP response reads at the declared size limit

### DIFF
--- a/src/gi.rs
+++ b/src/gi.rs
@@ -1,6 +1,7 @@
 use log::debug;
 use reqwest::blocking::Client;
 use reqwest::StatusCode;
+use std::io::Read;
 use std::time::Duration;
 use url::Url;
 
@@ -140,14 +141,7 @@ pub fn gi_command(target: &str) -> std::io::Result<String> {
         "HTTP GET {url} -> {status} ({:.0}ms)",
         started.elapsed().as_millis()
     );
-    let body = match response.text() {
-        Ok(s) => s,
-        Err(e) => {
-            return Err(std::io::Error::other(format!(
-                "Failed to get {target} from {url}: {e}"
-            )));
-        }
-    };
+    let body = read_response_body_string(response, &format!("get {target} from {url}"))?;
     validate_gi_response(status, body, target, &url)
 }
 
@@ -180,15 +174,25 @@ pub fn gi_list() -> std::io::Result<Vec<String>> {
         "HTTP GET {url} -> {status} ({:.0}ms)",
         started.elapsed().as_millis()
     );
-    let body = match response.text() {
-        Ok(s) => s,
-        Err(e) => {
-            return Err(std::io::Error::other(format!(
-                "Failed to get list from {url}: {e}"
-            )));
-        }
-    };
+    let body = read_response_body_string(response, &format!("get list from {url}"))?;
     validate_gi_list_response(status, body, &url)
+}
+
+fn read_response_body_string(
+    response: reqwest::blocking::Response,
+    context: &str,
+) -> std::io::Result<String> {
+    let limit = MAX_RESPONSE_BYTES as u64 + 1;
+    let mut buf = Vec::new();
+    if let Err(e) = response.take(limit).read_to_end(&mut buf) {
+        return Err(std::io::Error::other(format!("Failed to {context}: {e}")));
+    }
+    if buf.len() as u64 >= limit {
+        return Err(std::io::Error::other(format!(
+            "Failed to {context}: response body too large (> {MAX_RESPONSE_BYTES} bytes)"
+        )));
+    }
+    String::from_utf8(buf).map_err(|e| std::io::Error::other(format!("Failed to {context}: {e}")))
 }
 
 #[cfg(test)]

--- a/src/gibo.rs
+++ b/src/gibo.rs
@@ -157,9 +157,15 @@ fn kill_process_group(process_group_id: libc::pid_t) -> std::io::Result<()> {
     Err(err)
 }
 
-fn read_to_end(mut reader: impl Read) -> std::io::Result<Vec<u8>> {
+fn read_to_end(reader: impl Read) -> std::io::Result<Vec<u8>> {
+    let limit = MAX_SUBPROCESS_OUTPUT_BYTES as u64 + 1;
     let mut bytes = Vec::new();
-    reader.read_to_end(&mut bytes)?;
+    reader.take(limit).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 >= limit {
+        return Err(std::io::Error::other(format!(
+            "subprocess output exceeds {MAX_SUBPROCESS_OUTPUT_BYTES} bytes"
+        )));
+    }
     Ok(bytes)
 }
 
@@ -436,5 +442,21 @@ mod tests {
     fn test_gibo_command_fail() {
         let result = gibo_command("unknown-language");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_read_to_end_rejects_oversized_output() {
+        let data = vec![0u8; MAX_SUBPROCESS_OUTPUT_BYTES + 1];
+        let reader = std::io::Cursor::new(data);
+        let err = read_to_end(reader).unwrap_err();
+        assert!(err.to_string().contains("exceeds"));
+    }
+
+    #[test]
+    fn test_read_to_end_accepts_max_bytes() {
+        let data = vec![0u8; MAX_SUBPROCESS_OUTPUT_BYTES];
+        let reader = std::io::Cursor::new(data.clone());
+        let result = read_to_end(reader).unwrap();
+        assert_eq!(result.len(), MAX_SUBPROCESS_OUTPUT_BYTES);
     }
 }


### PR DESCRIPTION
## Summary

- `MAX_SUBPROCESS_OUTPUT_BYTES` and `MAX_RESPONSE_BYTES` declared an upper bound on accepted data, but `read_to_end` / `response.text()` read the full stream into memory before the size check ran. A subprocess or HTTP server sending more than the limit could cause the process to hold substantially more memory than intended before the error was returned.
- `read_to_end` in `gibo.rs` now uses `take(limit + 1)` so the read stops at the boundary and returns an error immediately. The kernel pipe buffer is the only memory held above the limit.
- `response.text()` in `gi.rs` is replaced by a bounded read via the `Read` trait on `reqwest::blocking::Response`. A shared helper `read_response_body_string` avoids duplicating the pattern across `gi_command` and `gi_list`.

## Details

The post-read checks in `validate_gibo_command_output` and `validate_gi_response` are kept as defence-in-depth for callers that pass pre-built strings directly (e.g. unit tests). The new behaviour is: for live subprocess / HTTP paths, the error fires before the full payload is materialised.

No new dependencies are required: `reqwest::blocking::Response` already implements `std::io::Read`.

## Verification

`cargo test` — 88 tests pass (81 unit + 2 CLI + 5 integration).  
`cargo clippy` — no new warnings.