### PR TITLE
Enforce explicit permissions block on all workflow files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,3 +72,19 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo build
+
+  workflow-permissions:
+    name: Workflow permissions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Verify all workflows declare explicit permissions
+        run: |
+          failed=0
+          for f in .github/workflows/*.yml; do
+            if ! grep -q '^permissions:' "$f"; then
+              echo "ERROR: $f is missing a top-level permissions block" >&2
+              failed=1
+            fi
+          done
+          exit "$failed"


### PR DESCRIPTION
All existing `.github/workflows/*.yml` files already declare a top-level
`permissions:` block, but nothing in CI enforced this invariant. A future
workflow added without an explicit block would silently inherit the
repository default, which is currently `write`.

This PR adds a `workflow-permissions` CI job that iterates over every
workflow file and fails if any is missing a top-level `permissions:`
line. The check runs on every pull request and catches regressions
before merge.

**Note for repository admin**: the repository-level defaults should also
be corrected in GitHub Settings → Actions → General → Workflow permissions:
- Set "Default permissions" to **Read repository contents and packages**
- Uncheck **Allow GitHub Actions to create and approve pull requests**

Or via CLI:
```sh
gh api -X PUT /repos/gitignore-in/gitignore-in/actions/permissions/workflow \
  --field default_workflow_permissions=read \
  --field can_approve_pull_request_reviews=false
```
