### PR TITLE
ci: add push-to-main trigger to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: tests
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

Adds a `push: branches: [main]` trigger to `.github/workflows/test.yml`.

## Why

The test workflow previously only ran on `pull_request` events. Commits that land on `main` without going through a PR — such as Renovate autoMerge or direct pushes — bypassed `cargo test` entirely.

The `octocov.yml` workflow does run on `push: main` and executes `cargo llvm-cov` (which runs tests as part of coverage collection), but the dedicated test matrix with `cargo check`, `cargo test`, `cargo fmt`, `cargo clippy`, and `cargo build` jobs did not run on main commits.

## Change

```diff
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
```

No jobs were modified; only the trigger is extended.
