### PR TITLE
fix: sync Cargo.lock in set-version.sh and add CONTRIBUTING/SECURITY docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing
+
+## Development
+
+Install a stable Rust toolchain. All CI checks can be reproduced locally:
+
+```sh
+cargo fmt --all -- --check   # formatting
+cargo clippy -- -D warnings  # lint
+cargo test                   # tests
+cargo build                  # build
+```
+
+Shell scripts are formatted with `shfmt`:
+
+```sh
+go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh
+```
+
+## Releasing
+
+Releases are cut from `main`. The release workflow is:
+
+1. **Prepare the release PR** (via workflow dispatch on `prepare release PR`):
+   - Runs `scripts/set-version.sh <version>` which updates both `Cargo.toml` and `Cargo.lock`.
+   - Opens a PR from `release/v<version>` into `main`.
+2. **Review and merge the release PR**: CI runs `cargo publish --dry-run` against the release branch.
+3. **Create a GitHub release** tagged `v<version>`: this triggers `cargo publish` (production) and the binary release workflow.
+
+### Why both Cargo.toml and Cargo.lock must be updated
+
+`scripts/set-version.sh` updates both files in one step. Updating only `Cargo.toml`
+leaves `Cargo.lock` with the old `gitignore-in` version; the subsequent `cargo build`
+in CI regenerates `Cargo.lock` locally but does not commit it, so `main` retains a
+stale lock after merge. The perl substitution in `set-version.sh` keeps both files
+in sync as part of the release PR diff.
+
+## Dependency updates
+
+Renovate manages most dependency updates automatically. For dependency PRs that fail
+CI, check whether the `Cargo.lock` has diverged from `Cargo.toml`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Report vulnerabilities privately via
+[GitHub's private vulnerability reporting](https://github.com/gitignore-in/gitignore-in/security/advisories/new)
+or by email to `kitsuyui+security@kitsuyui.com`.
+
+Include:
+- A description of the vulnerability and its potential impact.
+- Steps to reproduce or a proof-of-concept.
+- The version(s) affected, if known.
+
+## Scope
+
+This project uses the following components that may be relevant for vulnerability tracking:
+
+- **OpenSSL** (vendored via `openssl` crate with `vendored = true`): TLS for HTTPS requests.
+- **reqwest**: HTTP client library.
+
+## Response
+
+We aim to acknowledge reports within 7 days and provide a fix timeline within 30 days
+for confirmed vulnerabilities.

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -8,3 +8,4 @@ if [ -z "${version}" ]; then
 fi
 
 perl -0pi -e 's/^version = ".*"$/version = "'"${version}"'"/m' Cargo.toml
+perl -0pi -e 's/(name = "gitignore-in"\nversion = )"[^"]*"/$1"'"${version}"'"/m' Cargo.lock


### PR DESCRIPTION
## Why

`scripts/set-version.sh` updated only `Cargo.toml` when preparing a release,
leaving `Cargo.lock` with the old `gitignore-in` version. The subsequent
`cargo build --release` in the publish workflow regenerated `Cargo.lock`
locally but never committed it, so `main` retained a stale self-version
entry after every release PR merge. This is a minor reproducibility gap:
`cargo install` and local `cargo build` still work correctly, but the
committed lock file diverged from what was published to crates.io.

Additionally, there was no written guide for contributors or maintainers
(`CONTRIBUTING.md` was absent) and no security vulnerability reporting
channel (`SECURITY.md` was absent), making the release process opaque and
leaving the OpenSSL vendored dependency without a documented CVE response path.

## What changed

- **`scripts/set-version.sh`**: added a second `perl` substitution that
  updates the `gitignore-in` version entry in `Cargo.lock` in the same step
  as the `Cargo.toml` update. This keeps both files in sync in the release PR
  diff with no change to external dependency pins.
- **`CONTRIBUTING.md`**: documents the dev workflow (`cargo fmt/clippy/test`)
  and the release process, including why both `Cargo.toml` and `Cargo.lock`
  must be updated together.
- **`SECURITY.md`**: documents the private vulnerability reporting channel
  (GitHub private advisory) and the scope (vendored OpenSSL, reqwest).

## Verification

- `shfmt -d scripts/set-version.sh` — no formatting differences.
- `shellcheck scripts/set-version.sh` — no issues.
- `typos CONTRIBUTING.md SECURITY.md scripts/set-version.sh` — no spelling errors.
- Collateral check (`check-pr-collateral.py`) — clean, no violations.
- No Rust source changes; cargo test/clippy/fmt results are unchanged.

## Out of scope

- Removing `--allow-dirty` from `cratesio-publish.yml` (target/ artifacts
  always make the tree dirty; requires a separate clean-tree publish approach).
- Adding `--locked` to `test.yml` CI commands (behavioral change, separate finding).
