### PR TITLE
fix: return InvalidInput error kind for missing template in remove/add commands

### DIFF
--- a/src/edit.rs
+++ b/src/edit.rs
@@ -161,10 +161,13 @@ pub(crate) fn remove_templates(
         .cloned()
         .collect();
     if !missing.is_empty() {
-        return Err(std::io::Error::other(format!(
-            "Template(s) not found in .gitignore.in: {}",
-            missing.join(", ")
-        )));
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "Template(s) not found in .gitignore.in: {}",
+                missing.join(", ")
+            ),
+        ));
     }
     let mut removed = Vec::new();
 
@@ -226,9 +229,10 @@ fn resolve_template(
 ) -> std::io::Result<TemplateRef> {
     let matches = catalog.matches(query);
     if matches.is_empty() {
-        return Err(std::io::Error::other(format!(
-            "Template `{query}` was not found in gibo or gitignore.io"
-        )));
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Template `{query}` was not found in gibo or gitignore.io"),
+        ));
     }
 
     if let Some(existing_provider) = preferred_provider(script) {
@@ -424,6 +428,7 @@ mod tests {
             .expect_err("expected unknown template error");
 
         assert!(error.to_string().contains("unknown"));
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
     }
 
     #[test]
@@ -436,6 +441,7 @@ mod tests {
             .expect_err("expected missing template error");
 
         assert!(error.to_string().contains("node"));
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
     }
 
     #[test]


### PR DESCRIPTION
When a template name is not found in `remove_templates` (`src/edit.rs:164`) and
`resolve_template` (`src/edit.rs:229`), the functions previously returned
`io::Error::other(...)`, which maps to `ErrorKind::Other` → exit code 1 (general error).

Per the documented exit code contract in README, a missing or invalid template
name is user input error and should map to `ErrorKind::InvalidInput` → exit code 2
(usage error). The same fix was applied to size-limit errors in `parse_path` via PR #328.

This change makes `gitignore.in remove <nonexistent>` and `gitignore.in add <nonexistent>`
consistently return exit code 2, so callers can distinguish user input mistakes from
internal failures.

## Changes

- `remove_templates`: use `io::Error::new(io::ErrorKind::InvalidInput, ...)` when template not found
- `resolve_template`: same fix for the `add` command path
- Added `assert_eq!(error.kind(), io::ErrorKind::InvalidInput)` assertions to both existing tests

## Verification

- `cargo test`: 100 tests pass (93 unit + 2 cli_output + 5 integration)
- `cargo fmt --check`: clean
- `cargo clippy -- -D warnings`: clean
