### PR TITLE
fix: filter lockFileMaintenance noise from release notes, add MSRV and SemVer policy

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,8 @@
+changelog:
+  categories:
+    - title: What's Changed
+      labels:
+        - "*"
+  exclude:
+    labels:
+      - dependencies

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>kitsuyui/renovate-config"
-  ]
+  ],
+  "lockFileMaintenance": {
+    "labels": ["dependencies"]
+  }
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "gitignore-in"
 version = "0.2.1"
 edition = "2021"
+rust-version = "1.74"
 authors = ["Yui Kitsu <kitsuyui+github@kitsuyui.com>"]
 description = "A command line tool for managing .gitignore files with gitignore.in"
 license = "BSD-3-Clause"

--- a/README.md
+++ b/README.md
@@ -190,6 +190,17 @@ $ cd gitignore-in
 $ cargo install --path .
 ```
 
+## Versioning and compatibility
+
+This project is currently at `0.x.y`. Under SemVer, the `0.x` range does not
+guarantee backward compatibility between minor versions. Breaking changes may
+be introduced in any `0.x` release; they are noted in the GitHub release body.
+A migration to `1.0` with a stable API contract is planned once the CLI
+interface stabilises.
+
+**Minimum Supported Rust Version (MSRV):** 1.74. Raising the MSRV is treated
+as a minor-version change and will be documented in the release notes.
+
 ## License
 
 BSD-3-Clause. See [LICENSE](./LICENSE) for the full text.


### PR DESCRIPTION
## Summary

Release notes for v0.2.1 contained 231 bullet points, of which 148 (64%)
were `Lock file maintenance` entries from renovate. This made it hard to
spot user-visible changes. Additionally, the MSRV and SemVer compatibility
policy were not documented anywhere in the repo.

This PR makes three minimal changes:

- **`.github/release.yml`** — Adds a release-note exclusion rule: PRs
  labelled `dependencies` are filtered out of the auto-generated changelog.
- **`.github/renovate.json5`** — Extends the shared renovate config to add
  the `dependencies` label to `lockFileMaintenance` PRs, so the exclusion
  rule above can match them.
- **`Cargo.toml`** — Adds `rust-version = "1.74"` to document the MSRV
  (driven by the `clap 4.5+` requirement).
- **`README.md`** — Adds a "Versioning and compatibility" section stating
  the `0.x` SemVer policy and the MSRV.

## Behaviour after this PR

- Future `Lock file maintenance` PRs from renovate will be labelled
  `dependencies` and omitted from the GitHub release-note body.
- Other renovate PRs (security updates, version bumps) are not affected and
  will still appear in release notes.
- The MSRV is now machine-readable (`rust-version` in Cargo.toml) and
  human-readable (README).

## Trade-offs

- Past releases are not retroactively changed; the v0.2.1 notes remain
  unchanged on GitHub.
- The `dependencies` label must exist on the repo for GitHub to display it
  correctly; renovate will create it automatically when it opens the first
  labelled PR.
- The `1.0` roadmap is mentioned but not committed to a timeline.
