### PR TITLE
fix: return InvalidInput for reserved echo prefix in build.rs

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -52,10 +52,13 @@ pub(crate) fn build(script: GitIgnoreIn) -> std::io::Result<String> {
             }
             GitIgnoreStatement::Echo(Echo::Content(echo)) => {
                 if echo.starts_with("# gibo dump ") || echo.starts_with("# gi ") {
-                    return Err(std::io::Error::other(format!(
-                        "echo content {echo:?} starts with a reserved section header prefix; \
-                         use a different prefix to avoid ambiguity during restore"
-                    )));
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        format!(
+                            "echo content {echo:?} starts with a reserved section header prefix; \
+                             use a different prefix to avoid ambiguity during restore"
+                        ),
+                    ));
                 }
                 result.push_str(&separator());
                 result.push_str(&format!("{echo}\n"));
@@ -160,6 +163,7 @@ echo hello
         let text = "echo '# gibo dump Rust'\n";
         let script = parse_text(text);
         let err = build(script).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
         assert!(err.to_string().contains("reserved section header prefix"));
     }
 
@@ -168,6 +172,7 @@ echo hello
         let text = "echo '# gi Rust'\n";
         let script = parse_text(text);
         let err = build(script).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
         assert!(err.to_string().contains("reserved section header prefix"));
     }
 


### PR DESCRIPTION
## Summary

`build::build` returned `ErrorKind::Other` when an `echo` line in `.gitignore.in`
started with a reserved section header prefix (`# gibo dump ` or `# gi `).
`ErrorKind::Other` maps to exit code 1 (general error) via `exit_code_for_error`,
but this is a user input mistake that should produce exit code 2 (`EXIT_USAGE_ERROR`).

The same fix was already applied to `edit.rs`'s `remove_templates` and
`resolve_template` in PR #341. This PR brings `build.rs` in line with that pattern.

## Changes

- `src/build.rs`: Replace `std::io::Error::other(...)` with
  `std::io::Error::new(std::io::ErrorKind::InvalidInput, ...)` for the
  reserved-prefix echo check.
- Updated `test_echo_with_gibo_prefix_is_rejected` and
  `test_echo_with_gi_prefix_is_rejected` to assert `err.kind() == InvalidInput`
  in addition to the existing message check.

## Verification

```
cargo fmt   # no diff
cargo clippy  # no warnings
cargo test  # 97 unit + 2 cli + 5 integration tests pass
```

## Trade-offs

Single-line change confined to `build.rs`. No API or behaviour change beyond
the exit code for this specific error path. Scripts or CI checking `$? == 2`
for user input errors will now see the correct exit code for reserved-prefix
echo lines.