### PR TITLE
fix: keep provider content line-delimited

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -36,7 +36,7 @@ pub(crate) fn build(script: GitIgnoreIn) -> std::io::Result<String> {
                 };
                 result.push_str(&separator());
                 result.push_str(&format!("# gibo dump {target}\n"));
-                result.push_str(&content);
+                push_external_content(&mut result, &content);
             }
             GitIgnoreStatement::Gi(Gi::Target(target)) => {
                 let content = if let Some(cached) = gi_cache.get(&target) {
@@ -48,7 +48,7 @@ pub(crate) fn build(script: GitIgnoreIn) -> std::io::Result<String> {
                 };
                 result.push_str(&separator());
                 result.push_str(&format!("# gi {target}\n"));
-                result.push_str(&content);
+                push_external_content(&mut result, &content);
             }
             GitIgnoreStatement::Echo(Echo::Content(echo)) => {
                 if echo.starts_with("# gibo dump ") || echo.starts_with("# gi ") {
@@ -69,6 +69,13 @@ pub(crate) fn build(script: GitIgnoreIn) -> std::io::Result<String> {
         }
     }
     Ok(result)
+}
+
+fn push_external_content(result: &mut String, content: &str) {
+    result.push_str(content);
+    if !content.ends_with('\n') {
+        result.push('\n');
+    }
 }
 
 fn separator() -> String {
@@ -153,6 +160,24 @@ echo hello
         let script = parse_text(text);
         let result = build(script).unwrap();
         assert_eq!(result.matches("# gibo dump C++").count(), 2);
+    }
+
+    #[test]
+    fn external_content_without_trailing_newline_stays_line_delimited() {
+        let mut result = String::new();
+        push_external_content(&mut result, "*.swp");
+        result.push_str(&separator());
+
+        assert_eq!(result, "*.swp\n# -----------------------------------------------------------------------------\n");
+    }
+
+    #[test]
+    fn external_content_with_trailing_newline_is_not_changed() {
+        let mut result = String::new();
+        push_external_content(&mut result, "*.swp\n");
+        result.push_str(&separator());
+
+        assert_eq!(result, "*.swp\n# -----------------------------------------------------------------------------\n");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Keep provider template output line-delimited before the next generated section is appended.
- Add regression coverage for provider output with and without a trailing newline.

## Validation
- `cargo test`
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo build`
- `go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh`
- `typos`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color`
- Workflow permissions check for `.github/workflows/*.yml`
- Collateral check: clean
