### PR TITLE
sanitize gi response body before embedding in error message

### DIFF
--- a/src/gi.rs
+++ b/src/gi.rs
@@ -16,6 +16,14 @@ fn build_client() -> std::io::Result<Client> {
 }
 
 const BASE_URL: &str = "https://www.toptal.com/developers/gitignore/api/";
+const MAX_ERROR_BODY_CHARS: usize = 200;
+
+fn sanitize_error_body(body: &str) -> String {
+    body.chars()
+        .filter(|c| !c.is_control())
+        .take(MAX_ERROR_BODY_CHARS)
+        .collect()
+}
 
 fn target_url(target: &str) -> std::io::Result<Url> {
     let mut url = Url::parse(BASE_URL)
@@ -61,7 +69,8 @@ fn validate_gi_response(
     }
     if body.contains("ERROR") && body.contains("is undefined") {
         return Err(std::io::Error::other(format!(
-            "Failed to get {target} from {url}: {body}"
+            "Failed to get {target} from {url}: {}",
+            sanitize_error_body(&body)
         )));
     }
     Ok(body)
@@ -315,6 +324,45 @@ mod tests {
         let err = validate_gi_response(StatusCode::OK, body, "foo", &dummy_url()).unwrap_err();
         assert!(err.to_string().contains("ERROR"));
         assert!(err.to_string().contains("is undefined"));
+    }
+
+    #[test]
+    fn test_sanitize_error_body_strips_control_chars() {
+        // ESC (0x1b) and newline (0x0a) are control characters and are removed.
+        // Printable ANSI parameter bytes like '[', '3', '1', 'm' are kept but
+        // are harmless without the preceding ESC byte.
+        let body = "\x1b[31mERROR\x1b[0m: foo is undefined.\x0a";
+        assert_eq!(sanitize_error_body(body), "[31mERROR[0m: foo is undefined.");
+    }
+
+    #[test]
+    fn test_sanitize_error_body_truncates_long_input() {
+        let long = "A".repeat(MAX_ERROR_BODY_CHARS + 50);
+        let result = sanitize_error_body(&long);
+        assert_eq!(result.chars().count(), MAX_ERROR_BODY_CHARS);
+    }
+
+    #[test]
+    fn test_validate_gi_response_error_body_is_sanitized() {
+        // Embedded control characters in the API response body must not reach
+        // the error message verbatim.
+        let body = format!(
+            "\x1b[31mERROR\x1b[0m: rust is undefined.\x0a{}",
+            "x".repeat(300)
+        );
+        let err = validate_gi_response(StatusCode::OK, body, "rust", &dummy_url()).unwrap_err();
+        let msg = err.to_string();
+        // Control characters must be absent.
+        assert!(
+            !msg.chars().any(|c| c.is_control()),
+            "control char in: {msg:?}"
+        );
+        // Message is bounded (url/target prefix + up to MAX_ERROR_BODY_CHARS body).
+        assert!(
+            msg.len() < 512,
+            "error message unexpectedly long: {} chars",
+            msg.len()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The legacy-error branch in `validate_gi_response` embedded the raw HTTP
response body verbatim in the error string:

```rust
// before
"Failed to get {target} from {url}: {body}"
```

Untrusted content from the gitignore.io API could carry ANSI escape sequences
or other control characters that would reach the terminal or log aggregators
unchanged (terminal injection, log spoofing).

This PR introduces `sanitize_error_body` which:
- filters out all Unicode control characters (U+0000–U+001F, U+007F–U+009F),
  including ESC (the start of ANSI CSI sequences)
- truncates to 200 chars

The non-success path already limits external body data to byte-count only;
this change makes the legacy-error path symmetric.

## Changes

- `src/gi.rs`: add `sanitize_error_body`, apply to error message; add three
  unit tests (control-char stripping, truncation, end-to-end sanitization in
  `validate_gi_response`)

## Test plan

- [ ] `cargo test` passes (all 100 unit tests)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [ ] `cargo fmt --all -- --check` clean
- [ ] Existing `test_validate_gi_response_rejects_legacy_error_marker` still
      passes (normal error text has no control chars, so output is unchanged)