### PR TITLE
fix: correct TLS backend description in SECURITY.md from OpenSSL to rustls

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,7 +17,7 @@ Include:
 
 This project uses the following components that may be relevant for vulnerability tracking:
 
-- **OpenSSL** (vendored via `openssl` crate with `vendored = true`): TLS for HTTPS requests.
+- **rustls**: TLS implementation for HTTPS requests (via reqwest with rustls-tls backend).
 - **reqwest**: HTTP client library.
 
 ## Response


### PR DESCRIPTION
## Summary

- SECURITY.md listed OpenSSL (vendored via `openssl` crate) as the TLS backend, which is incorrect.
- The actual TLS implementation is **rustls** (via reqwest with rustls-tls backend).
- Confirmed: `openssl` crate is not present in `Cargo.lock`. Active TLS packages: rustls, hyper-rustls, tokio-rustls, rustls-platform-verifier.
- `openssl-probe` (present in `Cargo.lock`) is only used for certificate path detection, not as a TLS implementation.

## Verification

- Cargo.lock inspected: no `openssl` entry found.
- `cargo clippy --all-targets --all-features -- -D warnings` passes.

## Trade-offs

This is a minimal documentation correction. The TLS backend mismatch was introduced in commit 931dc24 when SECURITY.md was first added. No code changes required.
