### PR TITLE
fix: validate release version input

### DIFF
--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -32,7 +32,9 @@ jobs:
           fi
 
       - name: Set release version
-        run: ./scripts/set-version.sh "${{ inputs.version }}"
+        env:
+          VERSION: ${{ inputs.version }}
+        run: ./scripts/set-version.sh "${VERSION}"
 
       - name: Create release pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -7,5 +7,10 @@ if [ -z "${version}" ]; then
 	exit 1
 fi
 
-perl -0pi -e 's/^version = ".*"$/version = "'"${version}"'"/m' Cargo.toml
-perl -0pi -e 's/(name = "gitignore-in"\nversion = )"[^"]*"/$1"'"${version}"'"/m' Cargo.lock
+if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+	echo "version must be in x.y.z format: ${version}" >&2
+	exit 2
+fi
+
+VERSION="${version}" perl -0pi -e 's/^version = ".*"$/version = "$ENV{VERSION}"/m' Cargo.toml
+VERSION="${version}" perl -0pi -e 's/(name = "gitignore-in"\nversion = )"[^"]*"/$1"$ENV{VERSION}"/m' Cargo.lock


### PR DESCRIPTION
## Summary

- validate release version strings before updating Cargo metadata
- pass the workflow-dispatch version through a step environment variable before invoking the release script
- read the validated version from the environment inside the Perl replacements

## Tests

- `./scripts/set-version.sh 0.2.1`
- `./scripts/set-version.sh '1.2.3;system("echo injected")'` exits 2 with the expected validation error
- `cargo test`
- `cargo fmt --all -- --check`
- `go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color`
- `git diff --check`
- workflow permissions check
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo build`
- collateral check: clean

`implement-validator` is not installed in this environment, so that foreground gate could not be run locally.
