### PR TITLE
fix: avoid script injection in prepare-next-development-pr workflow

### DIFF
--- a/.github/workflows/prepare-next-development-pr.yml
+++ b/.github/workflows/prepare-next-development-pr.yml
@@ -44,8 +44,10 @@ jobs:
           echo "next_version=${next_version}" >> "${GITHUB_OUTPUT}"
 
       - name: Set next development version
+        env:
+          NEXT_VERSION: ${{ steps.version.outputs.next_version }}
         run: |
-          perl -0pi -e 's/^version = ".*"$/version = "'"${{ steps.version.outputs.next_version }}"'"/m' Cargo.toml
+          perl -0pi -e 's/^version = ".*"$/version = "'"${NEXT_VERSION}"'"/m' Cargo.toml
 
       - name: Create next development pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8


### PR DESCRIPTION
## Summary

The "Set next development version" step was expanding
`${{ steps.version.outputs.next_version }}` directly inside the `run:` block,
which means GitHub Actions substitutes the value into the shell command string
before the shell sees it. If the value contains Perl or shell metacharacters
(e.g. `/`, `"`, `;`), the inline substitution can break the regex or execute
unintended code.

This change binds the output to `NEXT_VERSION` via the step's `env:` block
instead. The OS environment passes the value to the shell without command
substitution, preventing the injection path.

## Changes

- `.github/workflows/prepare-next-development-pr.yml`: add `env: NEXT_VERSION`
  to the "Set next development version" step and replace the inline
  `${{ ... }}` expression with `${NEXT_VERSION}`

## Verification

- `cargo fmt --all` — no changes
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test` — 7 tests passed

## Trade-offs

The Perl command still interpolates `${NEXT_VERSION}` via shell variable
expansion inside the single-quoted regex literal. Values with Perl metacharacters
(e.g. `/`) could still affect the regex; however this is the same pattern
already used in `scripts/set-version.sh` and the version string is
machine-computed (semver-like), so the practical risk is low. A more
defensive approach would delegate to `scripts/set-version.sh` or use
`cargo set-version` from cargo-edit, but that would also update `Cargo.lock`,
which changes the scope of this workflow.
