### PR TITLE
ci: add job timeouts to GitHub Actions

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -84,6 +84,7 @@ jobs:
             deployment_target: "14.0"
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Verify release version
@@ -139,6 +140,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:

--- a/.github/workflows/cratesio-publish.yml
+++ b/.github/workflows/cratesio-publish.yml
@@ -20,6 +20,7 @@ jobs:
       contents: read
     if: ${{ github.event_name == 'release' || startsWith(github.head_ref, 'release/') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Verify release version

--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -16,5 +16,6 @@ permissions:
 jobs:
   update-gitignore:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: gitignore-in/gh-action@98ab8a7225c88b81167bfef156dbad83c554aaf4 # v0.2.3

--- a/.github/workflows/happy.yml
+++ b/.github/workflows/happy.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   happy:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     name: happy
     continue-on-error: true
     steps:

--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   octocov:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     env:
       # For incremental builds
       CARGO_INCREMENTAL: 1

--- a/.github/workflows/prepare-downstream-release.yml
+++ b/.github/workflows/prepare-downstream-release.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   dispatch:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/prepare-next-development-pr.yml
+++ b/.github/workflows/prepare-next-development-pr.yml
@@ -21,6 +21,7 @@ permissions:
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 

--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 

--- a/.github/workflows/rehearse-downstream-on-main.yml
+++ b/.github/workflows/rehearse-downstream-on-main.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   resolve:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       released_version: ${{ steps.resolve.outputs.released_version }}
       candidate_version: ${{ steps.resolve.outputs.candidate_version }}
@@ -42,6 +43,7 @@ jobs:
 
   dispatch:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: resolve
     strategy:
       fail-fast: false

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -26,6 +27,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -38,6 +40,7 @@ jobs:
   format:
     name: Format
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -49,6 +52,7 @@ jobs:
   shell-format:
     name: Shell Format
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -59,6 +63,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -70,6 +75,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -79,6 +85,7 @@ jobs:
   workflow-permissions:
     name: Workflow permissions
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Verify all workflows declare explicit permissions


### PR DESCRIPTION
## Summary
- add explicit `timeout-minutes` limits to every GitHub Actions job
- use longer limits for release, coverage, and test jobs, and shorter limits for lightweight bot and dispatch jobs

## Validation
- verified every workflow job declares `timeout-minutes`
- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color`
- `cargo fmt --all -- --check`
- `go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh`
- `cargo check`
- `cargo test`
- `cargo clippy -- -D warnings`
