### PR TITLE
ci: add weekly monitoring workflow for Dependabot security updates status

### DIFF
--- a/.github/workflows/check-dependabot-security-updates.yml
+++ b/.github/workflows/check-dependabot-security-updates.yml
@@ -1,0 +1,40 @@
+name: Check Dependabot security updates
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'  # every Monday
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  administration: read
+
+jobs:
+  check-dependabot-security-updates:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check vulnerability alerts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/vulnerability-alerts" \
+            --silent --fail \
+            || {
+              echo "::error::Vulnerability alerts are disabled for ${{ github.repository }}."
+              echo "::error::Enable at: https://github.com/${{ github.repository }}/settings/security_analysis"
+              exit 1
+            }
+          echo "Vulnerability alerts are enabled."
+
+      - name: Check Dependabot security updates
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          status=$(gh api "repos/${{ github.repository }}" \
+            --jq '.security_and_analysis.dependabot_security_updates.status')
+          if [ "$status" != "enabled" ]; then
+            echo "::error::Dependabot security updates are disabled (status: $status)."
+            echo "::error::Enable at: https://github.com/${{ github.repository }}/settings/security_analysis"
+            exit 1
+          fi
+          echo "Dependabot security updates are enabled."


### PR DESCRIPTION
## Summary

Dependabot vulnerability alerts and Dependabot security updates are currently
disabled on this repository. Without them, CVEs affecting `reqwest`, `clap`,
and other crates.io dependencies are not automatically detected or surfaced as
PRs.

This PR adds a scheduled monitoring workflow that checks both settings every
Monday and fails visibly when either is disabled. The failure makes the missing
configuration persistent and actionable in the Actions tab.

## Changes

### `.github/workflows/check-dependabot-security-updates.yml` (new)

A weekly-scheduled workflow (`0 0 * * 1`) that:
1. Calls `gh api repos/{repository}/vulnerability-alerts` — fails if vulnerability alerts are disabled.
2. Reads `security_and_analysis.dependabot_security_updates.status` from the repo API — fails if not `"enabled"`.

The workflow requires `contents: read` and `administration: read` permissions.
No personal access token is needed beyond the default `GITHUB_TOKEN`.

## Next steps

Enable both settings via **Settings → Security → Code security and analysis**:
- ✅ Enable **Dependabot alerts**
- ✅ Enable **Dependabot security updates**

Once enabled, the monitoring workflow will pass automatically on the next run.
