### PR TITLE
add weekly monitoring for Dependabot security updates

### DIFF
--- a/.github/workflows/check-dependabot-security-updates.yml
+++ b/.github/workflows/check-dependabot-security-updates.yml
@@ -1,0 +1,21 @@
+name: Check Dependabot security updates
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'  # every Monday
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  administration: read
+
+jobs:
+  check-dependabot-security-updates:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Check Dependabot security updates
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: ./scripts/check-dependabot-security-updates.sh

--- a/scripts/check-dependabot-security-updates.sh
+++ b/scripts/check-dependabot-security-updates.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Check that Dependabot vulnerability alerts and security updates are enabled.
+#
+# Usage: ./scripts/check-dependabot-security-updates.sh
+#
+# Exit 1 if vulnerability alerts are disabled or Dependabot security updates
+# are disabled. Exit 0 if both are enabled.
+#
+# Environment variables:
+#   GH_TOKEN             - GitHub token (required; set by actions/github-token or
+#                          secrets.GITHUB_TOKEN in GitHub Actions)
+#   GITHUB_REPOSITORY    - owner/repo (default: gitignore-in/gitignore-in)
+
+set -eu
+
+REPO="${GITHUB_REPOSITORY:-gitignore-in/gitignore-in}"
+
+gh api "repos/${REPO}/vulnerability-alerts" \
+	--silent --fail ||
+	{
+		printf '::error::Vulnerability alerts are disabled for %s.\n' "${REPO}"
+		printf '::error::Enable at: https://github.com/%s/settings/security_analysis\n' "${REPO}"
+		exit 1
+	}
+echo "Vulnerability alerts are enabled."
+
+status=$(gh api "repos/${REPO}" \
+	--jq '.security_and_analysis.dependabot_security_updates.status')
+if [ "${status}" != "enabled" ]; then
+	printf '::error::Dependabot security updates are disabled (status: %s).\n' "${status}"
+	printf '::error::Enable at: https://github.com/%s/settings/security_analysis\n' "${REPO}"
+	exit 1
+fi
+echo "Dependabot security updates are enabled."


### PR DESCRIPTION
Add a weekly (Monday) monitoring workflow that checks whether Dependabot
vulnerability alerts and Dependabot security updates are enabled.

## Changes

- `.github/workflows/check-dependabot-security-updates.yml`: weekly schedule
  workflow that invokes the check script and fails visibly if either setting
  is disabled.
- `scripts/check-dependabot-security-updates.sh`: shell logic that calls the
  GitHub API to check vulnerability alerts and security updates status. Extracted
  to a script so the workflow contains no inline shell logic.

## Why

Dependabot vulnerability alerts and security updates are currently disabled
(`dependabot_security_updates.status = "disabled"`, `/vulnerability-alerts`
returns HTTP 404). When either is disabled, the workflow emits a GitHub Actions
error annotation with a link to GitHub Settings → Security → Code security and
analysis for a repository admin to enable them.

This workflow does not enable the settings automatically — a human admin action
is required.

## Verification

- `shfmt -d scripts/*.sh`: no formatting issues
- collateral check (`check-pr-collateral.py`): clean — no `gha-inline-script`,
  `version-shrink`, or `too-many-files` findings
