### PR TITLE
docs: clarify stdout/stderr contract for all subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,10 @@ $ gitignore.in restore
 ## Output and Exit Status
 
 `gitignore.in search` writes matching templates to stdout as tab-separated
-`provider<TAB>template` rows. Progress messages and errors are written to
-stderr so stdout can be piped to other tools.
+`provider<TAB>template` rows. All other subcommands (`gitignore.in`, `add`,
+`remove`, `infer`, `restore`) produce no stdout output. Progress messages such
+as "Generated .gitignore" and all errors are written to stderr across all
+subcommands.
 
 Exit status values are:
 


### PR DESCRIPTION
## Summary

The "Output and Exit Status" section described the stdout/stderr contract only for the `search` subcommand, leaving the behaviour of `add`, `remove`, `infer`, `restore`, and the default invocation undocumented.

All non-search subcommands write progress messages (e.g. "Generated .gitignore") to stderr and produce no stdout output. This PR makes that contract explicit so automation authors can rely on it without reading the source code.

## What changed

`README.md` — expanded the paragraph in "Output and Exit Status" to state that only `search` writes to stdout, and that all other subcommands write progress to stderr only.

## Verification

Confirmed against `src/main.rs`:
- `search`: `println!` → stdout
- `add`, `remove`, `restore`, `infer`, default: all use `eprintln!` → stderr only; no `println!` calls
