### PR TITLE
ci: add cargo audit security scanning to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,15 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo build
 
+  security-audit:
+    name: Security audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
   workflow-permissions:
     name: Workflow permissions
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

The CI had no step to check Cargo dependencies against the RustSec advisory database. A vulnerability in any of the 207 transitive dependencies (including vendored openssl, which is statically linked) would not be caught by CI — the only detection path was noticing a Renovate version-bump PR, which is not a reliable gate.

## Changes

- `.github/workflows/test.yml`: Add `security-audit` job using `rustsec/audit-check@v2.0.0` (SHA-pinned at `69366f33`). The job runs on every pull request and main push, and fails if `cargo audit` finds any advisory in the dependency tree.

## Verification

- `actionlint .github/workflows/test.yml`: no errors
- `shfmt -d scripts/*.sh`: no formatting issues (no shell scripts changed)
- collateral check (`check-pr-collateral.py`): clean

## Trade-offs

- Each CI run installs cargo-audit via the action's bundled binary (~seconds). Cached by `rustsec/audit-check` internally.
- If a new advisory is published for a dependency, this job will fail until the dependency is updated. This is the intended behavior.
- `deny.toml` (cargo-deny) would give finer control (allow/ignore specific advisories) but is a larger configuration surface; adding a plain `cargo audit` gate first keeps scope minimal.
