### PR TITLE
refactor: consolidate shell quoting into a shared module

### DIFF
--- a/src/edit.rs
+++ b/src/edit.rs
@@ -4,6 +4,7 @@ use crate::{
     gi::gi_list,
     gibo::gibo_list,
     script::{Comment, Echo, Gi, Gibo, GitIgnoreIn, GitIgnoreStatement, Invalid, Meaningless},
+    shell::shell_word,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -297,13 +298,6 @@ fn template_from_statement(statement: &GitIgnoreStatement) -> Option<TemplateRef
 
 fn normalize_target_key(text: &str) -> String {
     text.trim().to_lowercase()
-}
-
-fn shell_word(text: &str) -> String {
-    match shlex::try_quote(text) {
-        Ok(quoted) => quoted.into_owned(),
-        Err(_) => format!("'{}'", text.replace('\'', r#"'\''"#)),
-    }
 }
 
 #[cfg(test)]

--- a/src/infer.rs
+++ b/src/infer.rs
@@ -4,6 +4,7 @@ use crate::{
     gi::{gi_command, gi_list},
     gibo::{gibo_command, gibo_list},
     restore,
+    shell::{shell_quote, shell_word},
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -64,7 +65,7 @@ fn load_candidates(options: &InferOptions) -> std::io::Result<Vec<Candidate>> {
     for target in &gibo_targets {
         let content = gibo_command(target)?;
         candidates.push(Candidate {
-            command: format!("gibo dump {}", shell_quote_target(target)),
+            command: format!("gibo dump {}", shell_word(target)),
             lines: normalize_content(&content),
         });
     }
@@ -72,7 +73,7 @@ fn load_candidates(options: &InferOptions) -> std::io::Result<Vec<Candidate>> {
     for target in &gi_targets {
         let content = gi_command(target)?;
         candidates.push(Candidate {
-            command: format!("gi {}", shell_quote_target(target)),
+            command: format!("gi {}", shell_word(target)),
             lines: normalize_content(&content),
         });
     }
@@ -208,18 +209,6 @@ fn residual_lines(text: &str, matched_counts: &mut HashMap<String, usize>) -> Ve
     }
 
     result
-}
-
-fn shell_quote_target(text: &str) -> String {
-    if text.contains(|c: char| c.is_whitespace() || c == '\'') {
-        shell_quote(text)
-    } else {
-        text.to_string()
-    }
-}
-
-fn shell_quote(text: &str) -> String {
-    format!("'{}'", text.replace('\'', r#"'\''"#))
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod infer;
 mod parser;
 mod restore;
 mod script;
+mod shell;
 
 const AFTER_HELP: &str =
     "Official site: https://gitignore.in/\nRepository: https://github.com/gitignore-in/gitignore-in";

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -1,5 +1,6 @@
-use crate::format::{
-    GENERATED_HEADER_LINES as HEADER_LINES, LEGACY_GENERATED_HEADER_LINES, SEPARATOR,
+use crate::{
+    format::{GENERATED_HEADER_LINES as HEADER_LINES, LEGACY_GENERATED_HEADER_LINES, SEPARATOR},
+    shell::{shell_quote, shell_word},
 };
 
 pub(crate) fn restore(text: &str) -> String {
@@ -17,13 +18,13 @@ pub(crate) fn restore(text: &str) -> String {
             };
 
             if let Some(target) = section_head.strip_prefix("# gibo dump ") {
-                result.push(format!("gibo dump {}", shell_quote_target(target)));
+                result.push(format!("gibo dump {}", shell_word(target)));
                 skip_generated_section(&mut lines);
                 continue;
             }
 
             if let Some(target) = section_head.strip_prefix("# gi ") {
-                result.push(format!("gi {}", shell_quote_target(target)));
+                result.push(format!("gi {}", shell_word(target)));
                 skip_generated_section(&mut lines);
                 continue;
             }
@@ -71,18 +72,6 @@ where
 fn restore_comment_line(line: &str) -> Option<String> {
     line.strip_prefix("# #")
         .map(|comment| format!("#{comment}"))
-}
-
-fn shell_quote_target(text: &str) -> String {
-    if text.contains(|c: char| c.is_whitespace() || c == '\'') {
-        shell_quote(text)
-    } else {
-        text.to_string()
-    }
-}
-
-fn shell_quote(text: &str) -> String {
-    format!("'{}'", text.replace('\'', r#"'\''"#))
 }
 
 #[cfg(test)]

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,0 +1,46 @@
+/// Always wraps text in single quotes with proper single-quote escaping.
+/// Use this when the argument must be quoted unconditionally (e.g. `echo` lines).
+pub(crate) fn shell_quote(text: &str) -> String {
+    format!("'{}'", text.replace('\'', r#"'\''"#))
+}
+
+/// Returns the minimally-quoted form of text using POSIX rules via shlex.
+/// Returns the bare text when no quoting is required, and single-quoted
+/// form otherwise. Use this for template targets (gibo/gi).
+pub(crate) fn shell_word(text: &str) -> String {
+    match shlex::try_quote(text) {
+        Ok(quoted) => quoted.into_owned(),
+        Err(_) => format!("'{}'", text.replace('\'', r#"'\''"#)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_word_is_unchanged() {
+        assert_eq!(shell_word("Rust"), "Rust");
+    }
+
+    #[test]
+    fn word_with_space_is_single_quoted() {
+        assert_eq!(shell_word("Visual Studio"), "'Visual Studio'");
+    }
+
+    #[test]
+    fn dollar_sign_is_quoted() {
+        assert_eq!(shell_word("$VAR"), "'$VAR'");
+    }
+
+    #[test]
+    fn backtick_is_quoted() {
+        assert_eq!(shell_word("`cmd`"), "'`cmd`'");
+    }
+
+    #[test]
+    fn single_quote_in_text_is_quoted() {
+        // shlex uses double-quoting when the text contains a single quote
+        assert_eq!(shell_word("it's"), r#""it's""#);
+    }
+}


### PR DESCRIPTION
## Problem

Three modules had inconsistent shell quoting for template names written to `.gitignore.in`:

| File | Function | Behaviour |
|---|---|---|
| `src/edit.rs` | `shell_word()` | `shlex::try_quote()` — correct POSIX quoting |
| `src/infer.rs` | `shell_quote_target()` | hand-written — only checked for whitespace and `'` |
| `src/restore.rs` | `shell_quote_target()` | identical copy of `infer.rs` implementation |

The hand-written variant left template names containing `$`, `` ` ``, `\`, or `!` unquoted.
When `build` later calls `shlex::split()` to re-parse the line, those characters cause
misparses (variable expansion, command substitution, etc.).
The duplicated code also means a future quoting policy change must be applied in three places,
with drift risk if only one or two are updated.

## Change

- Add `src/shell.rs` with two functions:
  - `shell_word(text)` — delegates to `shlex::try_quote()` for POSIX-correct minimal quoting.
    Used for gibo/gi template targets in all three modules.
  - `shell_quote(text)` — unconditional single-quote wrapping with `'` escaping.
    Used for `echo` lines where always-quoting is the right default.
- Remove the duplicate `shell_quote_target()` / `shell_quote()` implementations from
  `infer.rs` and `restore.rs`.
- Remove the local `shell_word()` from `edit.rs`; all three modules now share the same
  implementation.

## Verification

- All 105 unit tests and 7 integration tests pass.
- `cargo clippy --all-targets --all-features -- -D warnings` clean.
- `cargo fmt --all -- --check` clean.
- The pre-existing `quotes_multiword_gibo_candidate_command` and
  `quotes_multiword_gi_target` tests confirm quoting behaviour is preserved.
- New tests in `src/shell.rs` cover plain words, space, `$`, and `` ` ``.

## Trade-offs

The `echo` lines still use unconditional single-quote wrapping rather than `shell_word()`.
Changing that would silently alter the format of existing `.gitignore.in` files
(`echo 'plain-entry'` → `echo plain-entry`), which is semantically equivalent but
breaks round-trip idempotency. Keeping `shell_quote()` for echo lines preserves
the current output format.