### PR TITLE
reject empty gibo list output as an error

### DIFF
--- a/src/gibo.rs
+++ b/src/gibo.rs
@@ -230,12 +230,18 @@ fn validate_gibo_list_output(
             stdout.len()
         )));
     }
-    Ok(stdout
+    let templates: Vec<String> = stdout
         .lines()
         .map(str::trim)
         .filter(|line| !line.is_empty())
         .map(ToString::to_string)
-        .collect())
+        .collect();
+    if templates.is_empty() {
+        return Err(std::io::Error::other(
+            "Failed to list templates from gibo: empty output (boilerplate DB may be uninitialized; run `gibo update`)",
+        ));
+    }
+    Ok(templates)
 }
 
 pub fn gibo_command(target: &str) -> std::io::Result<String> {
@@ -347,6 +353,21 @@ mod tests {
             validate_gibo_list_output(make_status(127), String::new(), "gibo: command failed")
                 .unwrap_err();
         assert!(err.to_string().contains("exit=127"));
+    }
+
+    #[test]
+    fn test_validate_gibo_list_output_rejects_empty_output() {
+        // exit 0 but no templates: uninitialized or corrupted boilerplate DB
+        let err = validate_gibo_list_output(make_status(0), String::new(), "").unwrap_err();
+        assert!(err.to_string().contains("empty output"));
+    }
+
+    #[test]
+    fn test_validate_gibo_list_output_rejects_whitespace_only_output() {
+        // exit 0 but only whitespace: should also be treated as empty
+        let err =
+            validate_gibo_list_output(make_status(0), "   \n\n  \n".to_string(), "").unwrap_err();
+        assert!(err.to_string().contains("empty output"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`validate_gibo_list_output` previously returned `Ok(vec![])` when `gibo list` exited 0 with empty stdout, silently treating an uninitialized or corrupted boilerplate DB as a normal result. `validate_gi_list_response` (the `gi` provider counterpart) already returns an `Err` for empty responses, so these two validators were asymmetric.

This change brings `validate_gibo_list_output` into symmetry: an empty template list after exit 0 is now an `Err` that suggests running `gibo update`.

## Changes

- `src/gibo.rs`: Collect the filtered template list into a `Vec` first, then return `Err` if it is empty, with a message pointing to `gibo update`.
- Two new unit tests: `test_validate_gibo_list_output_rejects_empty_output` and `test_validate_gibo_list_output_rejects_whitespace_only_output`.

## Verification

All existing and new unit tests pass (`cargo test validate_gibo_list_output`). `cargo fmt --check` and `cargo clippy -- -D warnings` are clean.
