### PR TITLE
fix: cap aggregate template content in infer::load_candidates

### DIFF
--- a/src/infer.rs
+++ b/src/infer.rs
@@ -50,8 +50,11 @@ pub(crate) fn infer_with_options(text: &str, options: &InferOptions) -> std::io:
     ))
 }
 
+const MAX_CANDIDATES_TOTAL_BYTES: usize = 200 * 1024 * 1024;
+
 fn load_candidates(options: &InferOptions) -> std::io::Result<Vec<Candidate>> {
     let mut candidates = Vec::new();
+    let mut total_bytes: usize = 0;
     let gibo_targets = match &options.gibo_targets {
         TemplateTargets::All => gibo_list()?,
         TemplateTargets::Explicit(targets) => targets.clone(),
@@ -63,6 +66,12 @@ fn load_candidates(options: &InferOptions) -> std::io::Result<Vec<Candidate>> {
 
     for target in &gibo_targets {
         let content = gibo_command(target)?;
+        total_bytes = total_bytes.saturating_add(content.len());
+        if total_bytes > MAX_CANDIDATES_TOTAL_BYTES {
+            return Err(std::io::Error::other(format!(
+                "aggregate template content exceeds {MAX_CANDIDATES_TOTAL_BYTES} bytes"
+            )));
+        }
         candidates.push(Candidate {
             command: format!("gibo dump {}", shell_quote_target(target)),
             lines: normalize_content(&content),
@@ -71,6 +80,12 @@ fn load_candidates(options: &InferOptions) -> std::io::Result<Vec<Candidate>> {
 
     for target in &gi_targets {
         let content = gi_command(target)?;
+        total_bytes = total_bytes.saturating_add(content.len());
+        if total_bytes > MAX_CANDIDATES_TOTAL_BYTES {
+            return Err(std::io::Error::other(format!(
+                "aggregate template content exceeds {MAX_CANDIDATES_TOTAL_BYTES} bytes"
+            )));
+        }
         candidates.push(Candidate {
             command: format!("gi {}", shell_quote_target(target)),
             lines: normalize_content(&content),
@@ -231,6 +246,14 @@ mod tests {
             command: command.to_string(),
             lines: lines.iter().map(|line| line.to_string()).collect(),
         }
+    }
+
+    #[test]
+    fn aggregate_byte_limit_is_above_per_item_limit() {
+        // Each provider fetch is capped at 10 MB; the aggregate limit must be
+        // meaningfully larger so typical all-templates loads are not rejected.
+        const PER_ITEM_MAX: usize = 10 * 1024 * 1024;
+        const { assert!(MAX_CANDIDATES_TOTAL_BYTES > PER_ITEM_MAX) };
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`infer::load_candidates()` accumulates template content from all providers into a `Vec<Candidate>` without any aggregate size ceiling. Each individual fetch was already limited to 10 MB (`MAX_SUBPROCESS_OUTPUT_BYTES` / `MAX_RESPONSE_BYTES`), but the total across all templates had no bound: a large provider catalog or future provider additions could exhaust heap.

This PR adds `MAX_CANDIDATES_TOTAL_BYTES = 200 MB` as an aggregate guard in `load_candidates()`. A running byte counter tracks the pre-normalization content length; when the total exceeds the limit the function returns an error immediately rather than continuing to accumulate.

### What changed

- `src/infer.rs`: add `MAX_CANDIDATES_TOTAL_BYTES` constant; track `total_bytes` in `load_candidates()`; return `io::Error` when the aggregate limit is exceeded.
- Added a const-assert test verifying that the aggregate limit exceeds the existing per-item limit (10 MB).

### Behaviour

Normal usage (current catalogs are well under 10 MB total) is unaffected. The error path is reached only if accumulated content grows past 200 MB, which is 20× the per-item ceiling.

### Trade-offs

The 200 MB ceiling is conservative relative to current usage but finite. If a future provider legitimately returns large catalogs, the limit can be raised by changing the constant. This is a surface fix: the structural alternative (streaming / lazy evaluation) would avoid holding all fetched content in memory, but that requires a deeper refactor of `infer_from_candidates` and is better motivated when a second related finding accumulates.