### PR TITLE
Skip bootstrap in remove mode to prevent partial state on failure

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -337,15 +337,17 @@ fn update_gitignore_in_file(mode: UpdateMode, templates: Vec<String>) -> std::io
         ));
     }
 
-    match bootstrap_gitignore_in_file() {
-        Ok(BootstrapStatus::Initialized) => {
-            eprintln!("Initialized .gitignore.in");
+    if matches!(mode, UpdateMode::Add) {
+        match bootstrap_gitignore_in_file() {
+            Ok(BootstrapStatus::Initialized) => {
+                eprintln!("Initialized .gitignore.in");
+            }
+            Ok(BootstrapStatus::Inferred) => {
+                eprintln!("Inferred .gitignore.in from .gitignore");
+            }
+            Ok(BootstrapStatus::AlreadyPresent) => {}
+            Err(e) => return Err(e),
         }
-        Ok(BootstrapStatus::Inferred) => {
-            eprintln!("Inferred .gitignore.in from .gitignore");
-        }
-        Ok(BootstrapStatus::AlreadyPresent) => {}
-        Err(e) => return Err(e),
     }
 
     let mut script = parse_gitignore_in_file()?;
@@ -515,6 +517,29 @@ mod tests {
             }
             _ => unreachable!(),
         }
+    }
+
+    #[test]
+    fn test_remove_does_not_create_file_when_not_found() {
+        let temp_dir = Temp::new_dir().expect("failed to create temp dir");
+        let _guard = CwdGuard::new(temp_dir.as_path());
+
+        assert!(!Path::new(".gitignore.in").exists());
+
+        let result = run(Cli {
+            command: Some(Commands::Remove {
+                templates: vec!["NonExistent".to_string()],
+            }),
+        });
+
+        assert!(
+            result.is_err(),
+            "remove on missing .gitignore.in should fail"
+        );
+        assert!(
+            !Path::new(".gitignore.in").exists(),
+            "remove must not create .gitignore.in as a side effect"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`update_gitignore_in_file` called `bootstrap_gitignore_in_file()` for
both `Add` and `Remove` modes. On a repository with no `.gitignore.in`
and no `.gitignore`, bootstrap wrote a header-only `.gitignore.in` to
disk before `remove_templates` could check whether the requested
template exists. When the template was absent, `remove_templates`
returned `InvalidInput` and the function exited early — but the file
written by bootstrap remained on disk.

This means `gitignore.in remove <NonExistentTemplate>` could
accidentally create `.gitignore.in` as a side effect of a failed
operation.

## Change

- Wrap the `bootstrap_gitignore_in_file()` call in
  `if matches!(mode, UpdateMode::Add)` so that `Remove` never triggers
  file creation.
- When `.gitignore.in` is absent, `parse_gitignore_in_file` returns
  `NotFound` without any write-side effect.
- Add a test (`test_remove_does_not_create_file_when_not_found`) that
  verifies `.gitignore.in` is not created when a `remove` fails on a
  repository where the file did not previously exist.

## Verification

- `cargo test`: all 108 tests pass including the new test.
- `cargo clippy --all-targets --all-features -- -D warnings`: no warnings.
- `cargo fmt --all -- --check`: no formatting issues.
