### PR TITLE
Anchor legacy error detection to the same line and target name

### DIFF
--- a/src/gi.rs
+++ b/src/gi.rs
@@ -67,7 +67,10 @@ fn validate_gi_response(
             "Failed to get {target} from {url}: empty response body"
         )));
     }
-    if body.contains("ERROR") && body.contains("is undefined") {
+    if body
+        .lines()
+        .any(|line| line.contains("ERROR") && line.contains(&format!("{target} is undefined")))
+    {
         return Err(std::io::Error::other(format!(
             "Failed to get {target} from {url}: {}",
             sanitize_error_body(&body)
@@ -324,6 +327,18 @@ mod tests {
         let err = validate_gi_response(StatusCode::OK, body, "foo", &dummy_url()).unwrap_err();
         assert!(err.to_string().contains("ERROR"));
         assert!(err.to_string().contains("is undefined"));
+    }
+
+    #[test]
+    fn test_validate_gi_response_does_not_reject_independent_error_keywords() {
+        // "ERROR" and "is undefined" appearing in unrelated parts of a valid template
+        // body must not trigger the legacy error detector.
+        let body = "# ERROR handling notes\n# Check if value is undefined before use".to_string();
+        let result = validate_gi_response(StatusCode::OK, body, "rust", &dummy_url());
+        assert!(
+            result.is_ok(),
+            "unrelated occurrences of ERROR and 'is undefined' must not cause false positive"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`validate_gi_response` detects a legacy gitignore.io error response
(HTTP 200 with an error body) using two independent
`body.contains("ERROR")` and `body.contains("is undefined")` calls.
Because the checks are independent, a valid template body that happens
to contain "ERROR" in one section and "is undefined" in another section
would be falsely rejected.

The actual API error format is a single-line marker:
`#!! ERROR: <target> is undefined. #!!`

## Change

- Replace the two independent `contains` calls with a line-level scan
  that requires both `"ERROR"` and `"<target> is undefined"` to appear
  on the same line. Anchoring on the specific target name prevents
  false positives where the two keywords occur in unrelated contexts.
- Add `test_validate_gi_response_does_not_reject_independent_error_keywords`
  to verify that templates with the two tokens on separate lines are
  accepted.

## Verification

- `cargo test`: all 108 tests pass including the new test.
- `cargo clippy --all-targets --all-features -- -D warnings`: no warnings.
- `cargo fmt --all -- --check`: no formatting issues.
