### PR TITLE
docs: export default-branch-baseline ruleset with required CI status checks

### DIFF
--- a/.github/rulesets/default-branch-baseline.json
+++ b/.github/rulesets/default-branch-baseline.json
@@ -1,0 +1,90 @@
+{
+    "_links": {
+        "html": {
+            "href": "https://github.com/gitignore-in/gitignore-in/rules/13625124"
+        },
+        "self": {
+            "href": "https://api.github.com/repos/gitignore-in/gitignore-in/rulesets/13625124"
+        }
+    },
+    "bypass_actors": [],
+    "conditions": {
+        "ref_name": {
+            "exclude": [],
+            "include": [
+                "refs/heads/main"
+            ]
+        }
+    },
+    "created_at": "2026-03-08T11:22:06.752+09:00",
+    "current_user_can_bypass": "never",
+    "enforcement": "active",
+    "id": 13625124,
+    "name": "default-branch-baseline",
+    "node_id": "RRS_lACqUmVwb3NpdG9yec4m46WLzgDP5yQ",
+    "rules": [
+        {
+            "parameters": {
+                "allowed_merge_methods": [
+                    "merge",
+                    "squash",
+                    "rebase"
+                ],
+                "dismiss_stale_reviews_on_push": false,
+                "require_code_owner_review": false,
+                "require_last_push_approval": false,
+                "required_approving_review_count": 0,
+                "required_review_thread_resolution": false,
+                "required_reviewers": []
+            },
+            "type": "pull_request"
+        },
+        {
+            "type": "non_fast_forward"
+        },
+        {
+            "type": "deletion"
+        },
+        {
+            "parameters": {
+                "do_not_enforce_on_create": false,
+                "required_status_checks": [
+                    {
+                        "context": "Check",
+                        "integration_id": 15368
+                    },
+                    {
+                        "context": "Test",
+                        "integration_id": 15368
+                    },
+                    {
+                        "context": "Format",
+                        "integration_id": 15368
+                    },
+                    {
+                        "context": "Shell Format",
+                        "integration_id": 15368
+                    },
+                    {
+                        "context": "Lint",
+                        "integration_id": 15368
+                    },
+                    {
+                        "context": "Build",
+                        "integration_id": 15368
+                    },
+                    {
+                        "context": "happy",
+                        "integration_id": 15368
+                    }
+                ],
+                "strict_required_status_checks_policy": false
+            },
+            "type": "required_status_checks"
+        }
+    ],
+    "source": "gitignore-in/gitignore-in",
+    "source_type": "Repository",
+    "target": "branch",
+    "updated_at": "2026-06-16T02:51:01.010+09:00"
+}


### PR DESCRIPTION
## Summary

The `default-branch-baseline` repository ruleset (ID 13625124) previously had
an empty `required_status_checks` list, meaning all CI jobs were optional and
a PR could be merged regardless of CI outcome.

This change:
1. **Applies** required status checks to the ruleset via the GitHub API —
   `Check`, `Test`, `Format`, `Shell Format`, `Lint`, `Build`, and `happy`
   are now required before merging to `main`.
2. **Records** the ruleset JSON in `.github/rulesets/default-branch-baseline.json`
   so the configuration is visible in version control and can be reviewed
   alongside code changes.

## Impact

- PRs that fail any of the seven required CI checks can no longer be merged
  to `main`.
- Renovate's `autoMerge` will now only trigger after all required checks pass,
  preventing accidental auto-merges on failing dependency updates.

## Test plan

- [ ] Verify the updated ruleset appears on the GitHub repository settings page
      under **Rules → Rulesets → default-branch-baseline**.
- [ ] Open a test PR and confirm the seven checks appear as required in the
      merge-readiness checklist.