### PR TITLE
Consume return values of add_templates and remove_templates

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -162,8 +162,10 @@ fn run(cli: Cli) -> std::io::Result<()> {
         Some(Commands::Search { queries }) => search_templates(queries),
         Some(Commands::Add { templates }) => {
             pin_boilerplates_if_requested()?;
-            update_gitignore_in_file(UpdateMode::Add, templates, &progress)?;
-            progress.message("Updated .gitignore.in");
+            let updated = update_gitignore_in_file(UpdateMode::Add, templates, &progress)?;
+            if updated > 0 {
+                progress.message("Updated .gitignore.in");
+            }
             build_gitignore(&progress)
         }
         Some(Commands::Remove { templates }) => {
@@ -434,7 +436,7 @@ fn update_gitignore_in_file(
     mode: UpdateMode,
     templates: Vec<String>,
     progress: &Progress,
-) -> std::io::Result<()> {
+) -> std::io::Result<usize> {
     if templates.is_empty() {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
@@ -477,20 +479,18 @@ fn update_gitignore_in_file(
             ),
         ));
     }
-    match mode {
+    let changed = match mode {
         UpdateMode::Add => {
             let catalog = edit::Catalog::load()?;
-            edit::add_templates(&mut script, &catalog, &templates)?;
+            edit::add_templates(&mut script, &catalog, &templates)?.len()
         }
-        UpdateMode::Remove => {
-            edit::remove_templates(&mut script, &templates)?;
-        }
-    }
+        UpdateMode::Remove => edit::remove_templates(&mut script, &templates)?.len(),
+    };
     atomic_write(
         Path::new(".gitignore.in"),
         edit::render_with_line_ending(&script, line_ending),
     )?;
-    Ok(())
+    Ok(changed)
 }
 
 fn detect_gitignore_in_line_ending() -> std::io::Result<edit::LineEnding> {


### PR DESCRIPTION
## Summary

`add_templates` and `remove_templates` in `src/edit.rs` both return
`io::Result<Vec<TemplateRef>>` — the `Vec` carries the list of templates
that were actually added or removed. The sole caller,
`update_gitignore_in_file`, was discarding both `Vec` values via `?` and
unconditionally printing "Updated .gitignore.in" regardless of whether any
change occurred.

This means running `gitignore.in add Rust` a second time when `Rust` is
already present would print "Updated .gitignore.in" even though nothing
was added.

## Changes

- `update_gitignore_in_file` now returns `io::Result<usize>` (count of
  templates changed), obtained by calling `.len()` on the `Vec` returned
  by each editing function.
- For the `add` subcommand: "Updated .gitignore.in" is only printed when
  at least one template was actually added.
- For the `remove` subcommand: the message is still printed unconditionally
  because `remove_templates` already errors if any requested template is
  absent, so a successful return always means at least one template was
  removed.

## Testing

- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test` — 107 tests pass (100 unit + 7 integration)
