### PR TITLE
docs: document --version / -V flag in Usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Show the CLI help:
 $ gitignore.in --help
 ```
 
+Show the CLI version:
+
+```bash
+$ gitignore.in --version
+```
+
 Generate `.gitignore.in` if needed and build `.gitignore`:
 
 ```bash


### PR DESCRIPTION
## Summary

Add `--version` / `-V` to the Usage section of README.md.

The `--version` flag is auto-generated by clap via `#[command(version)]` in `src/main.rs`, so it has always been available. However, the Usage section only documented `--help`, leaving users no indication that version inspection is supported.

## Changes

- Added a "Show the CLI version" example block with `$ gitignore.in --version` immediately after the `--help` block

## Verification

- `cargo check` passes (no Rust changes, documentation only)
- Collateral check: clean (no version-shrink, gha-inline-script, or too-many-files findings)
