### PR TITLE
feat: add HTTP conditional GET cache to reduce redundant fetches

### DIFF
--- a/src/gi.rs
+++ b/src/gi.rs
@@ -76,6 +76,18 @@ fn validate_gi_response(
     Ok(body)
 }
 
+fn parse_gi_list_body(body: &str) -> std::io::Result<Vec<String>> {
+    if body.is_empty() {
+        return Err(std::io::Error::other("Cached list body is empty"));
+    }
+    Ok(body
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToString::to_string)
+        .collect())
+}
+
 fn validate_gi_list_response(
     status: StatusCode,
     body: String,
@@ -119,13 +131,20 @@ const USER_AGENT: &str = concat!("gitignore.in/", env!("CARGO_PKG_VERSION"));
 
 pub fn gi_command(target: &str) -> std::io::Result<String> {
     let url = target_url(target)?;
+    let url_str = url.as_str();
+    let cached = crate::http_cache::get(url_str);
     let client = build_client()?;
+    let mut request = client.get(url.clone()).header("User-Agent", USER_AGENT);
+    if let Some(ref c) = cached {
+        if let Some(ref etag) = c.etag {
+            request = request.header("If-None-Match", etag.as_str());
+        }
+        if let Some(ref lm) = c.last_modified {
+            request = request.header("If-Modified-Since", lm.as_str());
+        }
+    }
     let started = std::time::Instant::now();
-    let response = match client
-        .get(url.clone())
-        .header("User-Agent", USER_AGENT)
-        .send()
-    {
+    let response = match request.send() {
         Ok(r) => r,
         Err(e) => {
             let kind = if e.is_timeout() {
@@ -150,15 +169,52 @@ pub fn gi_command(target: &str) -> std::io::Result<String> {
         "HTTP GET {url} -> {status} ({:.0}ms)",
         started.elapsed().as_millis()
     );
+    if status == StatusCode::NOT_MODIFIED {
+        if let Some(entry) = cached {
+            return Ok(entry.body);
+        }
+        return Err(std::io::Error::other(format!(
+            "Got 304 Not Modified from {url} but no cached body"
+        )));
+    }
+    let etag = response
+        .headers()
+        .get("etag")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+    let last_modified = response
+        .headers()
+        .get("last-modified")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
     let body = read_response_body_string(response, &format!("get {target} from {url}"))?;
-    validate_gi_response(status, body, target, &url)
+    let result = validate_gi_response(status, body, target, &url)?;
+    crate::http_cache::put(
+        url_str,
+        &crate::http_cache::CacheEntry {
+            etag,
+            last_modified,
+            body: result.clone(),
+        },
+    );
+    Ok(result)
 }
 
 pub fn gi_list() -> std::io::Result<Vec<String>> {
     let url = format!("{BASE_URL}list?format=lines");
+    let cached = crate::http_cache::get(&url);
     let client = build_client()?;
+    let mut request = client.get(&url).header("User-Agent", USER_AGENT);
+    if let Some(ref c) = cached {
+        if let Some(ref etag) = c.etag {
+            request = request.header("If-None-Match", etag.as_str());
+        }
+        if let Some(ref lm) = c.last_modified {
+            request = request.header("If-Modified-Since", lm.as_str());
+        }
+    }
     let started = std::time::Instant::now();
-    let response = match client.get(&url).header("User-Agent", USER_AGENT).send() {
+    let response = match request.send() {
         Ok(r) => r,
         Err(e) => {
             let kind = if e.is_timeout() {
@@ -183,8 +239,35 @@ pub fn gi_list() -> std::io::Result<Vec<String>> {
         "HTTP GET {url} -> {status} ({:.0}ms)",
         started.elapsed().as_millis()
     );
+    if status == StatusCode::NOT_MODIFIED {
+        if let Some(entry) = cached {
+            return parse_gi_list_body(&entry.body);
+        }
+        return Err(std::io::Error::other(format!(
+            "Got 304 Not Modified from {url} but no cached body"
+        )));
+    }
+    let etag = response
+        .headers()
+        .get("etag")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+    let last_modified = response
+        .headers()
+        .get("last-modified")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
     let body = read_response_body_string(response, &format!("get list from {url}"))?;
-    validate_gi_list_response(status, body, &url)
+    let result = validate_gi_list_response(status, body.clone(), &url)?;
+    crate::http_cache::put(
+        &url,
+        &crate::http_cache::CacheEntry {
+            etag,
+            last_modified,
+            body,
+        },
+    );
+    Ok(result)
 }
 
 fn read_response_body_string(

--- a/src/http_cache.rs
+++ b/src/http_cache.rs
@@ -1,0 +1,176 @@
+use log::debug;
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+fn fnv1a(s: &str) -> u64 {
+    s.bytes().fold(14695981039346656037u64, |h, b| {
+        (h ^ b as u64).wrapping_mul(1099511628211)
+    })
+}
+
+fn resolve_cache_dir() -> Option<PathBuf> {
+    if let Ok(xdg) = std::env::var("XDG_CACHE_HOME") {
+        return Some(PathBuf::from(xdg).join("gitignore-in"));
+    }
+    let home = std::env::var("HOME").ok()?;
+    Some(PathBuf::from(home).join(".cache").join("gitignore-in"))
+}
+
+fn body_path(dir: &Path, hash: u64) -> PathBuf {
+    dir.join(format!("{hash:016x}.body"))
+}
+
+fn meta_path(dir: &Path, hash: u64) -> PathBuf {
+    dir.join(format!("{hash:016x}.meta"))
+}
+
+pub struct CacheEntry {
+    pub etag: Option<String>,
+    pub last_modified: Option<String>,
+    pub body: String,
+}
+
+fn get_from_dir(dir: &Path, url: &str) -> Option<CacheEntry> {
+    let hash = fnv1a(url);
+    let body = std::fs::read_to_string(body_path(dir, hash)).ok()?;
+    let meta = std::fs::read_to_string(meta_path(dir, hash))
+        .ok()
+        .unwrap_or_default();
+    let mut etag = None;
+    let mut last_modified = None;
+    for line in meta.lines() {
+        if let Some(v) = line.strip_prefix("etag: ") {
+            etag = Some(v.to_owned());
+        } else if let Some(v) = line.strip_prefix("last-modified: ") {
+            last_modified = Some(v.to_owned());
+        }
+    }
+    Some(CacheEntry {
+        etag,
+        last_modified,
+        body,
+    })
+}
+
+fn put_to_dir(dir: &Path, url: &str, entry: &CacheEntry) {
+    if let Err(e) = std::fs::create_dir_all(dir) {
+        debug!("http_cache: cannot create {}: {e}", dir.display());
+        return;
+    }
+    let hash = fnv1a(url);
+    if let Err(e) = atomic_write(dir, &body_path(dir, hash), entry.body.as_bytes()) {
+        debug!("http_cache: cannot write body for {url}: {e}");
+        return;
+    }
+    let mut meta = String::new();
+    if let Some(etag) = &entry.etag {
+        meta.push_str("etag: ");
+        meta.push_str(etag);
+        meta.push('\n');
+    }
+    if let Some(lm) = &entry.last_modified {
+        meta.push_str("last-modified: ");
+        meta.push_str(lm);
+        meta.push('\n');
+    }
+    if let Err(e) = atomic_write(dir, &meta_path(dir, hash), meta.as_bytes()) {
+        debug!("http_cache: cannot write meta for {url}: {e}");
+    }
+}
+
+pub fn get(url: &str) -> Option<CacheEntry> {
+    get_from_dir(&resolve_cache_dir()?, url)
+}
+
+pub fn put(url: &str, entry: &CacheEntry) {
+    let Some(dir) = resolve_cache_dir() else {
+        return;
+    };
+    put_to_dir(&dir, url, entry);
+}
+
+fn atomic_write(dir: &Path, dest: &Path, data: &[u8]) -> std::io::Result<()> {
+    let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
+    tmp.write_all(data)?;
+    tmp.persist(dest).map_err(|e| e.error)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fnv1a_differs_by_url() {
+        assert_ne!(
+            fnv1a("https://example.test/api/Rust"),
+            fnv1a("https://example.test/api/Go")
+        );
+    }
+
+    #[test]
+    fn test_fnv1a_empty_string() {
+        // FNV-1a of empty string is the offset basis itself
+        assert_eq!(fnv1a(""), 14695981039346656037u64);
+    }
+
+    #[test]
+    fn test_cache_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let url = "https://example.test/api/Rust";
+        let entry = CacheEntry {
+            etag: Some(r#""abc123""#.to_owned()),
+            last_modified: Some("Wed, 01 Jan 2025 00:00:00 GMT".to_owned()),
+            body: "### Rust ###\nfoo\n".to_owned(),
+        };
+        put_to_dir(tmp.path(), url, &entry);
+        let got = get_from_dir(tmp.path(), url).expect("cache should have an entry after put");
+        assert_eq!(got.body, entry.body);
+        assert_eq!(got.etag, entry.etag);
+        assert_eq!(got.last_modified, entry.last_modified);
+    }
+
+    #[test]
+    fn test_cache_miss_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let result = get_from_dir(tmp.path(), "https://example.test/api/nonexistent");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_cache_entry_without_etag() {
+        let tmp = tempfile::tempdir().unwrap();
+        let url = "https://example.test/api/Python";
+        let entry = CacheEntry {
+            etag: None,
+            last_modified: None,
+            body: "### Python ###\nfoo\n".to_owned(),
+        };
+        put_to_dir(tmp.path(), url, &entry);
+        let got =
+            get_from_dir(tmp.path(), url).expect("cache should have an entry after put");
+        assert_eq!(got.body, entry.body);
+        assert!(got.etag.is_none());
+        assert!(got.last_modified.is_none());
+    }
+
+    #[test]
+    fn test_cache_isolates_different_urls() {
+        let tmp = tempfile::tempdir().unwrap();
+        let url_a = "https://example.test/api/Rust";
+        let url_b = "https://example.test/api/Go";
+        put_to_dir(
+            tmp.path(),
+            url_a,
+            &CacheEntry {
+                etag: None,
+                last_modified: None,
+                body: "### Rust ###".to_owned(),
+            },
+        );
+        assert!(get_from_dir(tmp.path(), url_b).is_none());
+        assert!(get_from_dir(tmp.path(), url_a).is_some());
+    }
+}

--- a/src/http_cache.rs
+++ b/src/http_cache.rs
@@ -149,8 +149,7 @@ mod tests {
             body: "### Python ###\nfoo\n".to_owned(),
         };
         put_to_dir(tmp.path(), url, &entry);
-        let got =
-            get_from_dir(tmp.path(), url).expect("cache should have an entry after put");
+        let got = get_from_dir(tmp.path(), url).expect("cache should have an entry after put");
         assert_eq!(got.body, entry.body);
         assert!(got.etag.is_none());
         assert!(got.last_modified.is_none());

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod edit;
 mod format;
 mod gi;
 mod gibo;
+pub mod http_cache;
 mod infer;
 mod parser;
 mod restore;


### PR DESCRIPTION
## Summary

`gi_command` and `gi_list` previously discarded `ETag` and
`Last-Modified` response headers on every call, causing a full body
re-fetch on every invocation even when the upstream content had not
changed. This was explicitly deferred as "#2 HTTP cache header" in the
resolution of PR #296.

This PR adds a file-based HTTP conditional GET cache (`src/http_cache.rs`)
and wires it into both functions.

## Changes

**New: `src/http_cache.rs`**

- `get(url)` — reads cached ETag, Last-Modified, and body from
  `XDG_CACHE_HOME/gitignore-in/` (or `~/.cache/gitignore-in/`).
  Returns `None` on cache miss or if the cache directory is unavailable.
- `put(url, entry)` — writes body and headers atomically via
  `tempfile + rename` to prevent partial state on crash.
- URL → filename mapping uses FNV-1a hash (no external dependency).
- Cache write failures log at `debug!` and degrade gracefully to
  standard full fetch on the next call.

**Modified: `src/gi.rs`**

- `gi_command`: checks cache before each request, includes
  `If-None-Match` / `If-Modified-Since` if available, returns cached
  body on HTTP 304, updates cache on HTTP 200.
- `gi_list`: same pattern; the raw response body is cached so
  `parse_gi_list_body` can reconstruct the `Vec<String>` on a 304 hit.

**Modified: `src/main.rs`**

- Declares `pub mod http_cache`.

## Verification

- `cargo test`: 113 tests pass (106 unit + 2 CLI output + 5 integration).
  Includes 4 new unit tests for `http_cache` covering roundtrip,
  cache miss, entries without ETag/Last-Modified, and URL isolation.
- `cargo clippy`: no warnings.
- No new dependencies added.

## Trade-offs

- The gitignore.io API (`www.toptal.com`) may not return ETag or
  Last-Modified headers; if so, the cache stores body content with no
  validators and conditional GET headers are never sent. Behaviour
  degrades to the pre-existing full fetch with no regression.
- `git ls-tree`-level content dedup across invocations (e.g. CI) now
  requires the cache directory to be writable; CI runners typically have
  `~/.cache` available.