### PR TITLE
docs: document search without queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ This matches template names case-insensitively by substring:
 $ gitignore.in search macos rust
 ```
 
+Run `gitignore.in search` without queries to list every available template.
+
 Add templates without worrying about `gibo` vs `gi`.
 `gitignore.in` resolves names case-insensitively, prefers the provider already used in `.gitignore.in`, falls back to `gibo` when no provider is preferred, and rebuilds `.gitignore` after the update.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,9 +84,12 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Commands {
-    /// Search templates available from gibo and gitignore.io
+    /// Search templates available from gibo and gitignore.io.
+    ///
+    /// Omit queries to list every available template.
     Search {
-        /// Search terms matched case-insensitively against template names
+        /// Search terms matched case-insensitively against template names.
+        /// Omit to list every available template.
         queries: Vec<String>,
     },
     /// Add templates to .gitignore.in and rebuild .gitignore
@@ -504,6 +507,24 @@ mod tests {
             }
             _ => unreachable!(),
         }
+    }
+
+    #[test]
+    fn search_help_documents_empty_query_behavior() {
+        use clap::CommandFactory;
+
+        let mut command = Cli::command();
+        let search = command
+            .find_subcommand_mut("search")
+            .expect("search subcommand should exist");
+        let mut help = Vec::new();
+        search
+            .write_long_help(&mut help)
+            .expect("help should render");
+        let help = String::from_utf8(help).expect("help should be valid UTF-8");
+
+        assert!(help.contains("Omit queries to list every available template"));
+        assert!(help.contains("Omit to list every available template"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Document that `gitignore.in search` without queries lists every available template.
- Add a help-output regression test so the no-query behavior stays visible in CLI help.

## Verification
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo build`
- `typos README.md src tests Cargo.toml .github/workflows`
- `go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh`
- workflow permissions grep
- `actionlint .github/workflows/*.yml`
- collateral check clean

## Notes
- Release and binary packaging jobs are verified in GitHub Actions.
