### PR TITLE
test: add insta snapshot tests for --help and --version output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +261,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -433,6 +450,7 @@ version = "0.2.1"
 dependencies = [
  "clap",
  "env_logger",
+ "insta",
  "libc",
  "log",
  "mktemp",
@@ -701,6 +719,18 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "insta"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
+dependencies = [
+ "console",
+ "once_cell",
+ "similar",
+ "tempfile",
 ]
 
 [[package]]
@@ -1373,6 +1403,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,5 @@ tempfile = "3"
 url = "2.5"
 
 [dev-dependencies]
+insta = "1"
 mktemp = "0.5.1"

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,19 +3,21 @@ use std::process::Command;
 const BIN: &str = env!("CARGO_BIN_EXE_gitignore-in");
 
 #[test]
-fn help_flag_exits_successfully() {
+fn help_output_matches_snapshot() {
     let output = Command::new(BIN).arg("--help").output().unwrap();
     assert!(output.status.success());
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("Manage .gitignore files"));
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    insta::assert_snapshot!(stdout);
 }
 
 #[test]
-fn version_flag_exits_successfully() {
+fn version_output_format_matches_snapshot() {
     let output = Command::new(BIN).arg("--version").output().unwrap();
     assert!(output.status.success());
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("gitignore.in"));
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    // Normalize the version number so the snapshot stays valid across releases.
+    let normalized = stdout.replace(env!("CARGO_PKG_VERSION"), "<VERSION>");
+    insta::assert_snapshot!(normalized);
 }
 
 #[test]

--- a/tests/snapshots/integration_test__help_output_matches_snapshot.snap
+++ b/tests/snapshots/integration_test__help_output_matches_snapshot.snap
@@ -1,0 +1,22 @@
+---
+source: tests/integration_test.rs
+expression: stdout
+---
+Manage .gitignore files with .gitignore.in
+
+Usage: gitignore-in [COMMAND]
+
+Commands:
+  search   Search templates available from gibo and gitignore.io
+  add      Add templates to .gitignore.in and rebuild .gitignore
+  remove   Remove templates from .gitignore.in and rebuild .gitignore
+  restore  Restore .gitignore.in from a generated .gitignore and rebuild .gitignore
+  infer    Infer .gitignore.in from an existing .gitignore and rebuild .gitignore
+  help     Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+
+Official site: https://gitignore.in/
+Repository: https://github.com/gitignore-in/gitignore-in

--- a/tests/snapshots/integration_test__version_output_format_matches_snapshot.snap
+++ b/tests/snapshots/integration_test__version_output_format_matches_snapshot.snap
@@ -1,0 +1,5 @@
+---
+source: tests/integration_test.rs
+expression: normalized
+---
+gitignore.in <VERSION>


### PR DESCRIPTION
## Problem

The existing `--help` and `--version` tests only checked for substring presence with `contains()`. A change to option names, subcommand descriptions, or output format would silently pass.

## Solution

Replace with `insta` snapshot tests that capture the complete output. Any change to the help text or version format now causes an explicit test failure, making regressions visible. The version snapshot normalizes the semver number so it does not need updating on every release.

## Updating Snapshots

Run `INSTA_UPDATE=always cargo test` or `cargo insta review` to update snapshots after intentional output changes.

## Verification

All 107 tests pass, `cargo fmt` and `cargo clippy -D warnings` pass.

## Changes

- `Cargo.toml`: Added `insta = "1"` to `[dev-dependencies]`
- `Cargo.lock`: Updated lock file for insta dependency
- `tests/integration_test.rs`: Replaced `help_flag_exits_successfully` and `version_flag_exits_successfully` with `help_output_matches_snapshot` and `version_output_format_matches_snapshot` using insta snapshot assertions
- `tests/snapshots/integration_test__help_output_matches_snapshot.snap`: New snapshot capturing the full `--help` output
- `tests/snapshots/integration_test__version_output_format_matches_snapshot.snap`: New snapshot capturing `gitignore.in <VERSION>\n`