### PR TITLE
docs: clarify that providing one provider flag leaves the other unsearched

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -120,6 +120,8 @@ enum Commands {
     /// differ between runs if provider catalogs have been updated since the last
     /// run. For reproducible gibo results, set GITIGNORE_IN_BOILERPLATES_REF to a
     /// fixed commit SHA before running infer.
+    /// When only one of --gibo or --gi is provided, the other provider is not searched
+    /// (its candidate list is treated as empty).
     Infer {
         /// Comma-separated gibo targets to consider
         #[arg(long, value_delimiter = ',')]


### PR DESCRIPTION
## Summary

The `infer` subcommand help text documented the "both omitted" case (all templates
from both providers are checked) but did not mention what happens when only one of
`--gibo` or `--gi` is provided: the other provider's candidate list is treated as
empty and therefore not searched.

This omission created a gap between what users might reasonably expect
(`gitignore.in infer --gibo node` → still searches all gi templates) and what
actually happens (gi is not searched at all). The help text now states this
explicitly so users can plan their invocations accordingly.

## Changes

- `src/main.rs`: added two lines to the `Infer` subcommand docstring clarifying
  that providing only one provider flag leaves the other provider unsearched

## Verification

- `cargo fmt --check` — no changes
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --bin gitignore-in` — 100 passed, 0 failed
