### PR TITLE
fix: search no-match exits with general error (exit 1), not usage error (exit 2)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -218,7 +218,7 @@ fn search_templates(queries: Vec<String>) -> std::io::Result<()> {
         } else {
             format!("No templates matched: {}", queries.join(", "))
         };
-        return Err(std::io::Error::new(ErrorKind::InvalidInput, message));
+        return Err(std::io::Error::other(message));
     }
 
     for template in results {

--- a/tests/cli_output.rs
+++ b/tests/cli_output.rs
@@ -56,3 +56,30 @@ fn invalid_user_input_goes_to_stderr_once() {
     );
     assert!(!stderr.contains("InvalidInput"));
 }
+
+#[test]
+fn search_no_match_exits_with_general_error_not_usage_error() {
+    let temp_dir = Temp::new_dir().expect("failed to create temp dir");
+
+    let output = Command::new(binary())
+        .args(["search", "zzz-this-cannot-possibly-match-any-template"])
+        .current_dir(temp_dir.as_path())
+        .output()
+        .expect("failed to run gitignore-in");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "no-match search should exit 1 (general error), not 2 (usage error)"
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "stdout should stay reserved for data output: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("No templates matched"),
+        "stderr should explain the no-match result: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

When `search` produces no matching templates for a syntactically valid query, it returned exit code 2 (usage error) instead of exit code 1 (general error). This conflated two distinct outcomes that callers need to distinguish:

| Scenario | Before | After |
| --- | --- | --- |
| Valid query, no match: `search nonexistent` | exit 2 | exit 1 |
| Invalid argument: `add` (no templates) | exit 2 | exit 2 (unchanged) |

## Changes

- `src/main.rs`: Change `search_templates` to return `Error::other(message)` instead of `Error::new(ErrorKind::InvalidInput, message)` when results are empty. `ErrorKind::InvalidInput` maps to exit 2 (usage error); `ErrorKind::Other` maps to exit 1 (general error) via the existing fallthrough in `exit_code_for_error`.
- `tests/cli_output.rs`: Add integration test `search_no_match_exits_with_general_error_not_usage_error` that verifies exit code 1 and the error message on stderr.

## Motivation

The [grep(1)](https://man7.org/linux/man-pages/man1/grep.1.html) / curl(1) convention reserves exit 2 for syntax/argument errors and uses exit 1 for a successful invocation that found nothing. Automation scripts calling `gitignore.in search <query>` can now branch on the exit code without parsing the error message.

## Verification

```
test result: ok. 100 passed; 0 failed (unit tests)
test result: ok. 3 passed; 0 failed (integration tests, includes new test)
```

`cargo clippy --all-targets -- -D warnings` passes with no warnings.
