### PR TITLE
fix: include target and exit code in UTF-8 decoding errors in gibo.rs

### DIFF
--- a/src/gibo.rs
+++ b/src/gibo.rs
@@ -22,16 +22,24 @@ fn truncate_stderr(s: &str) -> String {
 
 pub fn gibo_root() -> std::io::Result<String> {
     let output = run_gibo_with_timeout(&["root"])?;
-    let stdout = String::from_utf8(output.stdout)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-    let stderr = String::from_utf8(output.stderr)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    let code = output
+        .status
+        .code()
+        .map(|c| c.to_string())
+        .unwrap_or_else(|| "<signal>".to_string());
+    let stdout = String::from_utf8(output.stdout).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("gibo root: stdout is not valid UTF-8 (exit={code}): {e}"),
+        )
+    })?;
+    let stderr = String::from_utf8(output.stderr).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("gibo root: stderr is not valid UTF-8 (exit={code}): {e}"),
+        )
+    })?;
     if !output.status.success() {
-        let code = output
-            .status
-            .code()
-            .map(|c| c.to_string())
-            .unwrap_or_else(|| "<signal>".to_string());
         return Err(std::io::Error::other(format!(
             "gibo root failed: exit={code} stderr={}",
             truncate_stderr(&stderr)
@@ -251,11 +259,21 @@ pub fn gibo_command(target: &str) -> std::io::Result<String> {
 
     let stdout = match String::from_utf8(output.stdout) {
         Ok(it) => it,
-        Err(err) => return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, err)),
+        Err(err) => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("gibo dump {target}: stdout is not valid UTF-8 (exit={code}): {err}"),
+            ))
+        }
     };
     let stderr = match String::from_utf8(output.stderr) {
         Ok(it) => it,
-        Err(err) => return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, err)),
+        Err(err) => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("gibo dump {target}: stderr is not valid UTF-8 (exit={code}): {err}"),
+            ))
+        }
     };
     validate_gibo_command_output(output.status, stdout, &stderr, target)
 }
@@ -272,11 +290,21 @@ pub fn gibo_list() -> std::io::Result<Vec<String>> {
     debug!("gibo list -> exit={code} ({elapsed_ms:.0}ms)");
     let stdout = match String::from_utf8(output.stdout) {
         Ok(it) => it,
-        Err(err) => return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, err)),
+        Err(err) => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("gibo list: stdout is not valid UTF-8 (exit={code}): {err}"),
+            ))
+        }
     };
     let stderr = match String::from_utf8(output.stderr) {
         Ok(it) => it,
-        Err(err) => return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, err)),
+        Err(err) => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("gibo list: stderr is not valid UTF-8 (exit={code}): {err}"),
+            ))
+        }
     };
     validate_gibo_list_output(output.status, stdout, &stderr)
 }


### PR DESCRIPTION
## Summary

When `gibo` produces output containing non-UTF-8 bytes (e.g., due to a locale
misconfiguration or a gibo implementation bug), the three call sites in `gibo.rs`
that call `String::from_utf8()` return only the raw `FromUtf8Error` message —
something like `"invalid utf-8 sequence of 1 bytes from index N"` — with no
indication of which operation failed, what template was requested, or what the
exit code was.

The detailed error format used by `validate_gibo_command_output()` (which
includes `target`, `exit code`, and `stderr`) does not apply to the UTF-8 decoding
path; only the success path reaches that function.

## Changes

- `src/gibo.rs` — three sites enriched:
  - `gibo_root()`: compute exit code before decoding; include `"gibo root"` context
    and exit code in both stdout and stderr UTF-8 errors.
  - `gibo_command()`: include `target` and the already-computed `code` in stdout
    and stderr UTF-8 errors.
  - `gibo_list()`: include `"gibo list"` context and the already-computed `code`
    in stdout and stderr UTF-8 errors.

Error messages now follow the same `"<operation>: <stream> is not valid UTF-8 (exit=<code>): <raw error>"` pattern, consistent with the existing detailed error format.

## Verification

- `cargo test` passes (all unit + integration tests).
- `cargo clippy --all-targets --all-features -- -D warnings` clean.
- `cargo fmt --all` — no formatting changes.

## Trade-offs

- The change is minimal: only the error-path `Err` branches are affected; the
  happy path is unchanged.
- Exit code extraction in `gibo_root()` is moved a few lines earlier (before
  stdout/stderr consumption) to make it available in the error closures.
