### PR TITLE
fix: return Invalid on echo lines with invalid shell quoting

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -32,7 +32,13 @@ pub fn parse_line(text: &str) -> GitIgnoreStatement {
         };
     }
     if let Some(stripped) = text.strip_prefix("echo ") {
-        return GitIgnoreStatement::Echo(Echo::Content(remove_shell_quote(stripped)));
+        let Some(parts) = shlex::split(stripped) else {
+            return GitIgnoreStatement::Invalid(Invalid::Line {
+                content: text.to_string(),
+                reason: format!("echo has invalid shell quoting: {stripped:?}"),
+            });
+        };
+        return GitIgnoreStatement::Echo(Echo::Content(parts.join(" ")));
     }
     if text.starts_with('#') {
         return GitIgnoreStatement::Comment(Comment::Content(text.to_string()));
@@ -54,14 +60,6 @@ fn parse_template_target(command: &str, text: &str) -> Result<String, String> {
             parts.join(", ")
         )),
     }
-}
-
-fn remove_shell_quote(text: &str) -> String {
-    let split = shlex::split(text);
-    if let Some(sp) = split {
-        return sp.join(" ");
-    }
-    text.to_string()
 }
 
 #[cfg(test)]
@@ -95,6 +93,17 @@ echo '!.gitignore'
             ],
         };
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn echo_with_invalid_quoting_returns_invalid() {
+        assert_eq!(
+            parse_line("echo it's"),
+            GitIgnoreStatement::Invalid(Invalid::Line {
+                content: "echo it's".to_string(),
+                reason: r#"echo has invalid shell quoting: "it's""#.to_string(),
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`remove_shell_quote()` in `src/parser.rs` silently returned the original text
when `shlex::split` failed (unclosed quote, `\0`, etc.).
This meant an `echo` line with invalid shell quoting — e.g. `echo it's` — was
passed through to `.gitignore` unchanged, writing the raw shell-quoted content
rather than an unquoted entry.

The silent fallback contradicted the function's implied contract and diverged
from how `gibo`/`gi` lines are handled: those return `Invalid::Line` on the
same parse failure.

## Change

- Remove `remove_shell_quote()`.
- Inline `shlex::split` in the `echo` branch of `parse_line`, using the same
  `let Some(parts) = shlex::split(...) else { return Invalid::Line { ... } }`
  pattern already used by `parse_template_target`.
- `echo` lines with invalid shell quoting now produce `Invalid::Line` instead
  of silently passing through.

## Verification

- All 101 unit tests and 7 integration tests pass (`cargo test`).
- `cargo clippy --all-targets --all-features -- -D warnings` clean.
- `cargo fmt --all` clean.
- New test `echo_with_invalid_quoting_returns_invalid` covers the failure path.

## Trade-offs

Valid `echo` lines that previously worked continue to work unchanged.
Any `.gitignore.in` file that contained an `echo` line with invalid shell
quoting (e.g. bare apostrophe) now produces a parse error rather than a
silently wrong `.gitignore` entry — this is the intended behaviour.
