### PR TITLE
Honor boilerplates ref during default rebuild

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -163,7 +163,10 @@ fn run(cli: Cli) -> std::io::Result<()> {
             eprintln!("Inferred .gitignore.in");
             build_gitignore()
         }
-        None => build_gitignore(),
+        None => {
+            pin_boilerplates_if_requested()?;
+            build_gitignore()
+        }
     }
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -52,6 +52,27 @@ fn build_with_existing_gitignore_in_produces_gitignore() {
 }
 
 #[test]
+fn default_build_reads_boilerplates_ref_env() {
+    let tmp = tempfile::tempdir().unwrap();
+    let output = Command::new(BIN)
+        .env(
+            "GITIGNORE_IN_BOILERPLATES_REF",
+            "gitignore-in-test-missing-ref",
+        )
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Cannot resolve \"gitignore-in-test-missing-ref\""),
+        "stderr should show that the default build read the ref env var: {stderr}"
+    );
+    assert!(!tmp.path().join(".gitignore").exists());
+}
+
+#[test]
 fn build_rejects_multiple_template_names_on_one_line() {
     let tmp = tempfile::tempdir().unwrap();
     std::fs::write(


### PR DESCRIPTION
## Summary

- Apply `GITIGNORE_IN_BOILERPLATES_REF` before the default rebuild path, matching add/remove/restore/infer behavior.
- Add a CLI regression test that proves an invalid boilerplates ref fails before `.gitignore` is generated.

## Changed Files

- `src/main.rs`
- `tests/integration_test.rs`

## Verification

- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo build`
- `typos`
- `go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh`
- workflow permissions check
- `cargo llvm-cov --lcov --output-path coverage.lcov`
- `git diff --check`
- `check-pr-collateral.py`: clean
- implement-validator: `overall: pass`

## Local Limitations

- The release workflow's full cross-target Linux/macOS matrix is not fully reproducible from this local machine; CI remains the source of truth for those target-specific builds.
