### PR TITLE
feat: allow tuning infer template overlap

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ $ gitignore.in remove RUST Node
 This infer mode is heuristic.
 It tries to cover the existing `.gitignore` with the specified `gibo dump ...` and `gi ...` candidates, then falls back to `echo '...'` for unmatched lines.
 If you omit both `--gibo` and `--gi`, it checks all available templates from both providers.
+By default, a candidate template must match at least two lines (`--min-overlap`)
+and at least 50% of that template's non-comment lines (`--min-overlap-percent`).
+Lower the percentage to accept sparser partial matches, or raise it to require
+tighter matches before a template is selected.
 
 Template scoring uses provider catalog content fetched at run time.
 Running `infer` again after a provider updates its catalog may produce different `.gitignore.in` output even for the same `.gitignore` input.

--- a/src/infer.rs
+++ b/src/infer.rs
@@ -7,6 +7,8 @@ use crate::{
     shell::{shell_quote, shell_word},
 };
 
+pub(crate) const DEFAULT_MIN_OVERLAP_PERCENT: u8 = 50;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct Candidate {
     pub(crate) command: String,
@@ -24,6 +26,7 @@ pub(crate) struct InferOptions {
     pub(crate) gibo_targets: TemplateTargets,
     pub(crate) gi_targets: TemplateTargets,
     pub(crate) min_overlap: usize,
+    pub(crate) min_overlap_percent: u8,
 }
 
 impl Default for InferOptions {
@@ -32,6 +35,7 @@ impl Default for InferOptions {
             gibo_targets: TemplateTargets::All,
             gi_targets: TemplateTargets::All,
             min_overlap: 2,
+            min_overlap_percent: DEFAULT_MIN_OVERLAP_PERCENT,
         }
     }
 }
@@ -49,6 +53,7 @@ pub(crate) fn infer_with_options(text: &str, options: &InferOptions) -> std::io:
         text,
         &candidates,
         options.min_overlap,
+        options.min_overlap_percent,
     ))
 }
 
@@ -102,6 +107,7 @@ pub(crate) fn infer_from_candidates(
     text: &str,
     candidates: &[Candidate],
     min_overlap: usize,
+    min_overlap_percent: u8,
 ) -> String {
     let normalized_lines = collect_target_lines(text);
     let mut remaining: BTreeSet<String> = normalized_lines.iter().cloned().collect();
@@ -109,7 +115,7 @@ pub(crate) fn infer_from_candidates(
     let mut matched_counts = HashMap::new();
 
     while let Some((best_index, overlap)) =
-        choose_best_candidate(candidates, &remaining, min_overlap)
+        choose_best_candidate(candidates, &remaining, min_overlap, min_overlap_percent)
     {
         let candidate = &candidates[best_index];
         selected_commands.push(candidate.command.clone());
@@ -136,6 +142,7 @@ fn choose_best_candidate(
     candidates: &[Candidate],
     remaining: &BTreeSet<String>,
     min_overlap: usize,
+    min_overlap_percent: u8,
 ) -> Option<(usize, Vec<String>)> {
     let mut best: Option<(usize, Vec<String>, usize)> = None;
 
@@ -155,7 +162,7 @@ fn choose_best_candidate(
             continue;
         }
 
-        if overlap.len() * 2 < candidate.lines.len() {
+        if !meets_min_overlap_percent(overlap.len(), candidate.lines.len(), min_overlap_percent) {
             continue;
         }
 
@@ -174,6 +181,14 @@ fn choose_best_candidate(
     }
 
     best.map(|(index, overlap, _)| (index, overlap))
+}
+
+fn meets_min_overlap_percent(
+    overlap_len: usize,
+    candidate_line_count: usize,
+    min_overlap_percent: u8,
+) -> bool {
+    overlap_len * 100 >= candidate_line_count * usize::from(min_overlap_percent)
 }
 
 fn collect_target_lines(text: &str) -> Vec<String> {
@@ -248,6 +263,7 @@ mod tests {
 
         assert_eq!(options.gibo_targets, TemplateTargets::All);
         assert_eq!(options.gi_targets, TemplateTargets::All);
+        assert_eq!(options.min_overlap_percent, DEFAULT_MIN_OVERLAP_PERCENT);
     }
 
     #[test]
@@ -259,7 +275,7 @@ mod tests {
             candidate("gibo dump Logs", &["custom.log"]),
         ];
 
-        let inferred = infer_from_candidates(text, &candidates, 2);
+        let inferred = infer_from_candidates(text, &candidates, 2, DEFAULT_MIN_OVERLAP_PERCENT);
         let expected = "gibo dump Rust\ngi node\n\necho 'custom.log'\n";
         assert_eq!(inferred, expected);
     }
@@ -269,16 +285,34 @@ mod tests {
         let text = "# existing comment\nnode_modules/\ndist/\n# keep this too\ncustom.log\n";
         let candidates = vec![candidate("gi node", &["node_modules/", "dist/", ".env"])];
 
-        let inferred = infer_from_candidates(text, &candidates, 2);
+        let inferred = infer_from_candidates(text, &candidates, 2, DEFAULT_MIN_OVERLAP_PERCENT);
         let expected = "gi node\n\n# existing comment\n# keep this too\necho 'custom.log'\n";
         assert_eq!(inferred, expected);
+    }
+
+    #[test]
+    fn min_overlap_percent_controls_sparse_template_matches() {
+        let text = "node_modules/\ndist/\n";
+        let candidates = vec![candidate(
+            "gi node",
+            &["node_modules/", "dist/", ".env", "coverage/"],
+        )];
+
+        let inferred_at_half = infer_from_candidates(text, &candidates, 2, 50);
+        assert_eq!(inferred_at_half, "gi node\n");
+
+        let inferred_at_three_quarters = infer_from_candidates(text, &candidates, 2, 75);
+        assert_eq!(
+            inferred_at_three_quarters,
+            "echo 'node_modules/'\necho 'dist/'\n"
+        );
     }
 
     #[test]
     fn quotes_multiword_gibo_candidate_command() {
         let candidates = vec![candidate("gibo dump 'Visual Studio'", &["*.suo", "*.user"])];
         let text = "*.suo\n*.user\n";
-        let inferred = infer_from_candidates(text, &candidates, 2);
+        let inferred = infer_from_candidates(text, &candidates, 2, DEFAULT_MIN_OVERLAP_PERCENT);
         assert_eq!(inferred, "gibo dump 'Visual Studio'\n");
     }
 
@@ -286,14 +320,14 @@ mod tests {
     fn quotes_multiword_gi_candidate_command() {
         let candidates = vec![candidate("gi 'Visual Studio'", &["*.suo", "*.user"])];
         let text = "*.suo\n*.user\n";
-        let inferred = infer_from_candidates(text, &candidates, 2);
+        let inferred = infer_from_candidates(text, &candidates, 2, DEFAULT_MIN_OVERLAP_PERCENT);
         assert_eq!(inferred, "gi 'Visual Studio'\n");
     }
 
     #[test]
     fn falls_back_when_no_candidate_matches() {
         let text = "# comment\ncustom.log\n";
-        let inferred = infer_from_candidates(text, &[], 2);
+        let inferred = infer_from_candidates(text, &[], 2, DEFAULT_MIN_OVERLAP_PERCENT);
         assert_eq!(inferred, "# comment\necho 'custom.log'\n");
     }
 
@@ -330,6 +364,7 @@ mod tests {
                 gibo_targets: TemplateTargets::Explicit(vec![]),
                 gi_targets: TemplateTargets::Explicit(vec![]),
                 min_overlap: 99,
+                min_overlap_percent: DEFAULT_MIN_OVERLAP_PERCENT,
             },
         )
         .unwrap();
@@ -351,7 +386,7 @@ mod tests {
             # Edit .gitignore.in instead of this file\n\
             # Run `gitignore.in` to build .gitignore\n\
             target/\n";
-        let infer_result = infer_from_candidates(generated, &[], 2);
+        let infer_result = infer_from_candidates(generated, &[], 2, DEFAULT_MIN_OVERLAP_PERCENT);
         let restore_result = restore::restore(generated);
         assert_ne!(infer_result, restore_result);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,6 +130,13 @@ enum Commands {
         /// Minimum number of matching lines required for a template
         #[arg(long, default_value_t = 2)]
         min_overlap: usize,
+        /// Minimum percentage of a template's lines that must match
+        #[arg(
+            long,
+            default_value_t = infer::DEFAULT_MIN_OVERLAP_PERCENT,
+            value_parser = clap::value_parser!(u8).range(0..=100)
+        )]
+        min_overlap_percent: u8,
     },
 }
 
@@ -180,10 +187,11 @@ fn run(cli: Cli) -> std::io::Result<()> {
             gibo,
             gi,
             min_overlap,
+            min_overlap_percent,
         }) => {
             pin_boilerplates_if_requested()?;
             refuse_if_gitignore_in_exists("infer")?;
-            let new_in = compute_inferred_gitignore_in(gibo, gi, min_overlap)?;
+            let new_in = compute_inferred_gitignore_in(gibo, gi, min_overlap, min_overlap_percent)?;
             let new_gitignore = build_content_from_str(&new_in)?;
             atomic_write(Path::new(".gitignore.in"), &new_in)?;
             eprintln!("Inferred .gitignore.in");
@@ -276,7 +284,12 @@ fn bootstrap_gitignore_in_file() -> std::io::Result<BootstrapStatus> {
     }
 
     if Path::new(".gitignore").exists() {
-        let content = compute_inferred_gitignore_in(Vec::new(), Vec::new(), 2)?;
+        let content = compute_inferred_gitignore_in(
+            Vec::new(),
+            Vec::new(),
+            2,
+            infer::DEFAULT_MIN_OVERLAP_PERCENT,
+        )?;
         atomic_write(path, content)?;
         return Ok(BootstrapStatus::Inferred);
     }
@@ -324,6 +337,7 @@ fn compute_inferred_gitignore_in(
     gibo_targets: Vec<String>,
     gi_targets: Vec<String>,
     min_overlap: usize,
+    min_overlap_percent: u8,
 ) -> std::io::Result<String> {
     let path = std::path::Path::new(".gitignore");
     let file = std::fs::File::open(path)?;
@@ -345,6 +359,7 @@ fn compute_inferred_gitignore_in(
             gibo_targets,
             gi_targets,
             min_overlap,
+            min_overlap_percent,
         },
     )?;
     Ok(add_gitignore_in_header(&inferred))
@@ -637,6 +652,8 @@ mod tests {
             "node",
             "--min-overlap",
             "3",
+            "--min-overlap-percent",
+            "75",
         ]);
 
         match cli.command {
@@ -644,10 +661,12 @@ mod tests {
                 gibo,
                 gi,
                 min_overlap,
+                min_overlap_percent,
             }) => {
                 assert_eq!(gibo, vec!["Rust".to_string(), "macOS".to_string()]);
                 assert_eq!(gi, vec!["node".to_string()]);
                 assert_eq!(min_overlap, 3);
+                assert_eq!(min_overlap_percent, 75);
             }
             _ => unreachable!(),
         }
@@ -854,6 +873,7 @@ mod tests {
                 gibo: Vec::new(),
                 gi: Vec::new(),
                 min_overlap: 2,
+                min_overlap_percent: infer::DEFAULT_MIN_OVERLAP_PERCENT,
             }),
         });
         assert!(result.is_ok(), "infer should succeed: {result:?}");
@@ -889,6 +909,7 @@ mod tests {
                 gibo: Vec::new(),
                 gi: Vec::new(),
                 min_overlap: 2,
+                min_overlap_percent: infer::DEFAULT_MIN_OVERLAP_PERCENT,
             }),
         });
 


### PR DESCRIPTION
## Summary

- Add `--min-overlap-percent` to make the infer template coverage threshold explicit and tunable.
- Keep the existing default behavior at 50% through a named default constant.
- Document how `--min-overlap` and `--min-overlap-percent` work together.

## Changed files

- `README.md`
- `src/infer.rs`
- `src/main.rs`

## Verification

- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo build`
- `typos`
- `go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh`
- `git diff --check`
- `check-pr-collateral.py --title "feat: allow tuning infer template overlap" --format md`
- implement-validator verdict schema validation with `overall: pass`
