### PR TITLE
fix: add RELEASE_PAT token to prepare-next-development-pr workflow

### DIFF
--- a/.github/workflows/prepare-next-development-pr.yml
+++ b/.github/workflows/prepare-next-development-pr.yml
@@ -43,6 +43,15 @@ jobs:
           fi
           echo "next_version=${next_version}" >> "${GITHUB_OUTPUT}"
 
+      - name: Require next development PR token
+        env:
+          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
+        run: |
+          if [ -z "${RELEASE_PAT}" ]; then
+            echo "RELEASE_PAT secret is required so the created PR triggers pull_request workflows." >&2
+            exit 1
+          fi
+
       - name: Set next development version
         run: |
           perl -0pi -e 's/^version = ".*"$/version = "'"${{ steps.version.outputs.next_version }}"'"/m' Cargo.toml
@@ -50,6 +59,7 @@ jobs:
       - name: Create next development pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
+          token: ${{ secrets.RELEASE_PAT }}
           branch: chore/next-development-version
           delete-branch: true
           commit-message: Bump to ${{ steps.version.outputs.next_version }}


### PR DESCRIPTION
## Summary

The `prepare-next-development-pr.yml` workflow creates a post-release version-bump PR using `peter-evans/create-pull-request` without an explicit `token`. GitHub Actions substitutes `GITHUB_TOKEN` in this case, and GitHub's security policy prevents PRs created with `GITHUB_TOKEN` from triggering other workflows — so the version-bump PR skips CI entirely.

`prepare-release-pr.yml` already avoids this by passing `token: secrets.RELEASE_PAT` and validating the secret's presence up front. `prepare-next-development-pr.yml` was missing the same treatment.

## Changes

- `.github/workflows/prepare-next-development-pr.yml`:
  - Add **Require next development PR token** step (fails early when `RELEASE_PAT` is unset, matching `prepare-release-pr.yml` line 25–31)
  - Add `token: ${{ secrets.RELEASE_PAT }}` to the `create-pull-request` step so the resulting PR triggers `pull_request` CI

## Verification

- `actionlint .github/workflows/prepare-next-development-pr.yml`: no errors

## Trade-offs

- Requires `RELEASE_PAT` secret to be configured before this workflow can run. If the secret is absent the workflow fails loudly at the new validation step rather than silently producing a PR that skips CI — this is the intended behavior, matching `prepare-release-pr.yml`.
- No change to the version-calculation logic or the Cargo.toml mutation step.