### PR TITLE
fix: strip control characters from subprocess stderr in gibo.rs

### DIFF
--- a/src/gibo.rs
+++ b/src/gibo.rs
@@ -10,14 +10,19 @@ const MAX_SUBPROCESS_OUTPUT_BYTES: usize = 10 * 1024 * 1024;
 const MAX_SUBPROCESS_STDERR_BYTES: usize = 4 * 1024;
 
 fn truncate_stderr(s: &str) -> String {
-    if s.len() <= MAX_SUBPROCESS_STDERR_BYTES {
-        return s.to_string();
+    let sanitized: String = s.chars().filter(|c| !c.is_control()).collect();
+    if sanitized.len() <= MAX_SUBPROCESS_STDERR_BYTES {
+        return sanitized;
     }
     let mut end = MAX_SUBPROCESS_STDERR_BYTES;
-    while !s.is_char_boundary(end) {
+    while !sanitized.is_char_boundary(end) {
         end -= 1;
     }
-    format!("{} ...[{} bytes truncated]", &s[..end], s.len() - end)
+    format!(
+        "{} ...[{} bytes truncated]",
+        &sanitized[..end],
+        sanitized.len() - end
+    )
 }
 
 pub fn gibo_root() -> std::io::Result<String> {
@@ -381,6 +386,20 @@ mod tests {
     fn test_truncate_stderr_short() {
         let s = "short error";
         assert_eq!(truncate_stderr(s), s);
+    }
+
+    #[test]
+    fn test_truncate_stderr_strips_control_chars() {
+        let s = "error: \x1b[31mfailed\x1b[0m";
+        let result = truncate_stderr(s);
+        assert!(
+            !result.contains('\x1b'),
+            "ANSI escape sequences should be stripped"
+        );
+        assert!(
+            result.contains("failed"),
+            "message content should be preserved"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`truncate_stderr` in `gibo.rs` truncates subprocess stderr to 4096 bytes but passes through control characters (ANSI escape sequences, etc.) unchanged. When `gibo` or `git` subprocesses emit coloured output, those escape codes flow into user-facing error messages via `eprintln\!("Error: {e}")`, creating a terminal escape injection path.

`gi.rs` already handles this for HTTP error bodies via `sanitize_error_body`, which filters control characters with `chars().filter(|c| \!c.is_control())`. `gibo.rs` was missing the equivalent guard.

## Changes

- `src/gibo.rs`: sanitize control characters in `truncate_stderr` before the byte-limit truncation
- `src/gibo.rs`: add `test_truncate_stderr_strips_control_chars` to cover the new behaviour

## Verification

- `cargo fmt --all -- --check`: clean
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test`: 101 tests passed (including the 3 `truncate_stderr` tests)

## Trade-offs

- Control characters that count toward the `MAX_SUBPROCESS_STDERR_BYTES` byte limit in the original string are removed before truncation, so the kept portion may be slightly longer than before. This is a safe change: the limit exists to bound memory, and the sanitized string is always ≤ the original length.
- The truncation message now reports sanitized-byte counts rather than raw-byte counts, which is more accurate for what the user actually sees.