### PR TITLE
fix: skip binary deploy for pre-release tags

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -136,7 +136,7 @@ jobs:
             ./artifacts
 
   deploy:
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') && !github.event.release.prerelease
     needs: build
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

The `deploy` job in `binary-release.yml` was unconditionally triggered for all
tags (including pre-release tags) via `if: startsWith(github.ref, 'refs/tags/')`.
Meanwhile, `cratesio-publish.yml` already correctly skips the crates.io publish
for pre-releases and only runs `--dry-run`.

This asymmetry means binaries are uploaded to GitHub Release even for
pre-release tags, while the crates.io publish is intentionally withheld.
Downstream tools (e.g. Homebrew formula auto-updaters) may pick up pre-release
binaries as if they were stable releases.

## Change

Add `&& \!github.event.release.prerelease` to the `deploy` job condition in
`binary-release.yml`, mirroring the existing guard in `cratesio-publish.yml`.

The `build` job still runs on `prereleased` events for CI validation — only the
GitHub Release upload step is skipped for pre-releases.

## Verification

- actionlint: no errors
- Logic matches the existing `cratesio-publish.yml` pattern at line 40–46