### PR TITLE
chore: bump version to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "gitignore-in"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitignore-in"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["Yui Kitsu <kitsuyui+github@kitsuyui.com>"]
 description = "A command line tool for managing .gitignore files with gitignore.in"


### PR DESCRIPTION
## Summary

The `search` subcommand's exit code for "no templates matched" changed from
exit 2 (`EXIT_USAGE_ERROR`) to exit 1 (`EXIT_GENERAL_ERROR`) in commit 0eedd2e
(PR #378). This is an observable behavioral change for callers who branch on
the exit code (e.g., shell scripts checking `$?`, CI jobs using exit code 2 to
detect "template not found" vs generic failure).

Per semantic versioning conventions, a patch release should accompany any
bug-fix that results in an observable behavior change.

## Change

Bump `version` in `Cargo.toml` and `Cargo.lock` from `0.2.1` to `0.2.2`.

## Verification

- No source code changes; version strings only
- `cargo check` and `cargo test` will verify the package compiles correctly
  at the new version