### PR TITLE
fix(ci): replace cargo install || true with conditional check in octocov workflow

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: coverage
         run: |
-          cargo install cargo-llvm-cov || true  # when already cached
+          command -v cargo-llvm-cov >/dev/null 2>&1 || cargo install --locked cargo-llvm-cov
           cargo llvm-cov --lcov --output-path coverage.lcov
 
       # See also: https://github.com/k1LoW/octocov-action


### PR DESCRIPTION
## Summary

The coverage step in `.github/workflows/octocov.yml` used `|| true` to suppress errors from `cargo install cargo-llvm-cov`:

```yaml
cargo install cargo-llvm-cov || true  # when already cached
```

`|| true` unconditionally silences **all** installation failures, including:
- Network outages (cache miss + crates.io unavailable)
- Compilation errors
- crates.io API failures

When installation fails silently, the subsequent `cargo llvm-cov` step fails with an indirect error (`no such subcommand: llvm-cov`), making the root cause harder to diagnose.

## Change

Replace with a conditional check that only skips installation when the binary is already in `PATH` (cache hit):

```yaml
command -v cargo-llvm-cov >/dev/null 2>&1 || cargo install --locked cargo-llvm-cov
```

- Cache hit: binary found in `PATH` → skip install (same behaviour as before)
- Cache miss: install proceeds, and failures surface as real errors
- `--locked`: uses `Cargo.lock` for reproducible dependency resolution

## Verification

- `actionlint` reports no issues on the modified workflow file
- No Rust source changes; existing CI coverage continues to apply