### PR TITLE
fix(release): add fail_on_unmatched_files to action-gh-release

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -154,3 +154,4 @@ jobs:
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           files: ./artifacts/*.tar.gz
+          fail_on_unmatched_files: true


### PR DESCRIPTION
## Summary

`softprops/action-gh-release` does not fail by default when its `files` glob
matches nothing. The binary release workflow uses `fail-fast: false` in the build
matrix, so an individual arch build failure does not block the `deploy` job.
If a build fails and leaves no artifact, the release step still succeeds and
publishes an incomplete release (missing that platform's binary).

Adding `fail_on_unmatched_files: true` causes the release step to fail when
any expected artifact file is absent, making incomplete releases visible as a
CI failure rather than a silently broken download page.

## Change

```yaml
- name: Release
  uses: softprops/action-gh-release@... # v3
  with:
    files: ./artifacts/*.tar.gz
    fail_on_unmatched_files: true   # ← added
```

## Verification

- `actionlint` reports no issues on the modified workflow file
- No Rust source changes; existing CI coverage continues to apply
- The artifact glob `./artifacts/*.tar.gz` is populated by the matrix
  `Archive artifact` step, so `fail_on_unmatched_files` only triggers when
  an arch's build or compress step did not produce output