### PR TITLE
Reject add/remove when .gitignore.in has invalid lines

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -349,6 +349,28 @@ fn update_gitignore_in_file(mode: UpdateMode, templates: Vec<String>) -> std::io
     }
 
     let mut script = parse_gitignore_in_file()?;
+    let invalid: Vec<String> = script
+        .content
+        .iter()
+        .filter_map(|s| {
+            if let script::GitIgnoreStatement::Invalid(script::Invalid::Line { content, reason }) =
+                s
+            {
+                Some(format!("{content:?}: {reason}"))
+            } else {
+                None
+            }
+        })
+        .collect();
+    if !invalid.is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                ".gitignore.in contains invalid line(s); fix or remove them before editing:\n{}",
+                invalid.join("\n")
+            ),
+        ));
+    }
     match mode {
         UpdateMode::Add => {
             let catalog = edit::Catalog::load()?;
@@ -613,6 +635,50 @@ mod tests {
         let err = parse_path(&path).unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
         assert!(err.to_string().contains("exceeds size limit"));
+    }
+
+    #[test]
+    fn add_rejects_gitignore_in_with_invalid_lines() {
+        let temp_dir = Temp::new_dir().expect("failed to create temp dir");
+        let _guard = CwdGuard::new(temp_dir.as_path());
+        std::fs::write(".gitignore.in", "gibo dump Rust\ngibo dump Rust macOS\n")
+            .expect("failed to write .gitignore.in");
+
+        let exit_code = run_cli(Cli {
+            command: Some(Commands::Add {
+                templates: vec!["node".to_string()],
+            }),
+        });
+
+        assert_eq!(exit_code, ExitCode::from(EXIT_USAGE_ERROR));
+        let preserved =
+            std::fs::read_to_string(".gitignore.in").expect("failed to read .gitignore.in");
+        assert!(
+            preserved.contains("gibo dump Rust macOS"),
+            ".gitignore.in must not be modified when invalid lines are present"
+        );
+    }
+
+    #[test]
+    fn remove_rejects_gitignore_in_with_invalid_lines() {
+        let temp_dir = Temp::new_dir().expect("failed to create temp dir");
+        let _guard = CwdGuard::new(temp_dir.as_path());
+        std::fs::write(".gitignore.in", "gibo dump Rust\ngibo dump Rust macOS\n")
+            .expect("failed to write .gitignore.in");
+
+        let exit_code = run_cli(Cli {
+            command: Some(Commands::Remove {
+                templates: vec!["Rust".to_string()],
+            }),
+        });
+
+        assert_eq!(exit_code, ExitCode::from(EXIT_USAGE_ERROR));
+        let preserved =
+            std::fs::read_to_string(".gitignore.in").expect("failed to read .gitignore.in");
+        assert!(
+            preserved.contains("gibo dump Rust macOS"),
+            ".gitignore.in must not be modified when invalid lines are present"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When `.gitignore.in` contains lines that the parser cannot handle
(e.g. `gibo dump Rust macOS` — multiple targets on one line),
`add` and `remove` now fail early with a clear error message instead of
silently writing a partially-updated file.

### Before

```
$ echo 'gibo dump Rust macOS' >> .gitignore.in
$ gitignore-in add node
Updated .gitignore.in     # ← misleading: the file was modified
Error: one template per line; found 2 template names: Rust, macOS
#
# .gitignore.in was rewritten but .gitignore was NOT regenerated,
# leaving the two files inconsistent.
```

### After

```
$ gitignore-in add node
Error: .gitignore.in contains invalid line(s); fix or remove them before editing:
"gibo dump Rust macOS": gibo dump expects one template per line; found 2 template names: Rust, macOS
#
# Neither file is modified. Exit code 2.
```

## Changes

- `update_gitignore_in_file` in `src/main.rs`: added a pre-flight check
  that collects any `Invalid` statements from the parsed script and returns
  `ErrorKind::InvalidInput` before performing any edit or `atomic_write`.
- Added two tests (`add_rejects_gitignore_in_with_invalid_lines`,
  `remove_rejects_gitignore_in_with_invalid_lines`) that verify:
  - exit code is `EXIT_USAGE_ERROR` (2)
  - `.gitignore.in` is not modified

## Trade-offs

The change does not attempt to repair or skip invalid lines — it stops
the operation entirely. Users must fix or remove the invalid line before
editing. This is the safest option because silently skipping invalid lines
would change the file's content in an unexpected way.