### PR TITLE
Strip control characters from gitignore.io success responses

### DIFF
--- a/src/gi.rs
+++ b/src/gi.rs
@@ -51,6 +51,12 @@ fn request_error(url: &str, e: &reqwest::Error) -> std::io::Error {
     std::io::Error::new(kind, format!("Failed to request to {url}: {reason}"))
 }
 
+fn sanitize_body(body: &str) -> String {
+    body.chars()
+        .filter(|c| !c.is_control() || matches!(c, '\n' | '\r' | '\t'))
+        .collect()
+}
+
 fn target_url(target: &str) -> std::io::Result<Url> {
     let mut url = Url::parse(BASE_URL)
         .map_err(|e| std::io::Error::other(format!("Invalid BASE_URL `{BASE_URL}`: {e}")))?;
@@ -103,7 +109,7 @@ fn validate_gi_response(
             sanitize_error_body(&body)
         )));
     }
-    Ok(body)
+    Ok(sanitize_body(&body))
 }
 
 fn parse_gi_list_body(body: &str) -> std::io::Result<Vec<String>> {
@@ -465,6 +471,28 @@ mod tests {
     }
 
     #[test]
+    fn test_sanitize_body_strips_non_whitespace_control_chars() {
+        // ESC (0x1b) and NUL (0x00) are removed; \n and \t are preserved.
+        let body = "\x00### template ###\n\x1b[32mfoo\x1b[0m\n\tindented\n";
+        assert_eq!(
+            sanitize_body(body),
+            "### template ###\n[32mfoo[0m\n\tindented\n"
+        );
+    }
+
+    #[test]
+    fn test_validate_gi_response_success_body_has_control_chars_stripped() {
+        // A 200 response body containing ANSI escapes must have those stripped
+        // before the content is returned to callers.
+        let body = "### X ###\n\x1b[32mfoo\x1b[0m\nbar\n".to_string();
+        let result = validate_gi_response(StatusCode::OK, body, "X", &dummy_url()).unwrap();
+        assert!(!result
+            .chars()
+            .any(|c| c.is_control() && !matches!(c, '\n' | '\r' | '\t')));
+        assert!(result.contains("foo"), "printable content must be preserved");
+        assert!(result.contains("bar"));
+    }
+
     fn test_sanitize_error_body_strips_control_chars() {
         // ESC (0x1b) and newline (0x0a) are control characters and are removed.
         // Printable ANSI parameter bytes like '[', '3', '1', 'm' are kept but

--- a/src/gi.rs
+++ b/src/gi.rs
@@ -489,7 +489,10 @@ mod tests {
         assert!(!result
             .chars()
             .any(|c| c.is_control() && !matches!(c, '\n' | '\r' | '\t')));
-        assert!(result.contains("foo"), "printable content must be preserved");
+        assert!(
+            result.contains("foo"),
+            "printable content must be preserved"
+        );
         assert!(result.contains("bar"));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -902,8 +902,8 @@ mod tests {
 
     #[test]
     fn add_preserves_existing_gitignore_in_crlf_line_endings() {
-        let temp_dir = Temp::new_dir().expect("failed to create temp dir");
-        let _guard = CwdGuard::new(temp_dir.as_path());
+        let temp_dir = TempDir::new().expect("failed to create temp dir");
+        let _guard = CwdGuard::new(temp_dir.path());
         std::fs::write(
             ".gitignore.in",
             "# See https://gitignore.in/\r\n# Edit this file and run `gitignore.in` to rebuild .gitignore\r\n\r\ngibo dump Rust\r\n",


### PR DESCRIPTION
## Summary

`validate_gi_response` in `src/gi.rs` already sanitized control
characters in the error path (when the body contains `"ERROR"` and
`"is undefined"`), but the success path returned the raw response body.

A proxy that injects ANSI escape sequences or other control characters
into an otherwise valid 200 response would embed those bytes directly
into `.gitignore`.

## Changes

Added `sanitize_body` which strips control characters while preserving
`\n`, `\r`, and `\t` — whitespace that is valid in gitignore content.
The success return in `validate_gi_response` is changed from `Ok(body)`
to `Ok(sanitize_body(&body))`, making the error and success paths
symmetric.

`sanitize_error_body` is unchanged: it additionally removes all
whitespace and truncates to `MAX_ERROR_BODY_CHARS`, which is appropriate
for short, human-readable error messages but not for template content.

## Tests

- `test_sanitize_body_strips_non_whitespace_control_chars`: verifies
  that `\x00` and `\x1b` are removed while `\n` and `\t` are kept.
- `test_validate_gi_response_success_body_has_control_chars_stripped`:
  end-to-end test on a 200 response body containing ANSI escapes.

## Trade-offs

The sanitization is applied on every successful fetch, adding a linear
scan over the body. Given that gitignore templates are typically a few
kilobytes, the overhead is negligible. The alternative (applying
sanitization only in the write path in `build.rs`) would require
threading the concern through more callers; sanitizing at the trust
boundary (`gi.rs`) is cleaner.