### PR TITLE
fix: strip control characters from gibo root path

### DIFF
--- a/src/gibo.rs
+++ b/src/gibo.rs
@@ -20,6 +20,10 @@ fn truncate_stderr(s: &str) -> String {
     format!("{} ...[{} bytes truncated]", &s[..end], s.len() - end)
 }
 
+fn strip_control_chars(s: &str) -> String {
+    s.chars().filter(|c| !c.is_control()).collect()
+}
+
 pub fn gibo_root() -> std::io::Result<String> {
     let output = run_gibo_with_timeout(&["root"])?;
     let code = output
@@ -45,7 +49,7 @@ pub fn gibo_root() -> std::io::Result<String> {
             truncate_stderr(&stderr)
         )));
     }
-    let root = stdout.trim().to_string();
+    let root = strip_control_chars(stdout.trim());
     if root.is_empty() {
         return Err(std::io::Error::other(
             "gibo root returned empty output; boilerplates database not initialised",
@@ -317,6 +321,30 @@ mod tests {
     fn make_status(code: i32) -> ExitStatus {
         // unix では exit code は (code << 8) で表現される。
         ExitStatus::from_raw(code << 8)
+    }
+
+    #[test]
+    fn test_strip_control_chars_removes_esc_from_ansi_sequences() {
+        // ANSI sequences start with ESC (0x1b, a control char). strip_control_chars
+        // removes the ESC byte, leaving the non-control remnant "[32m...[0m" harmless
+        // (no ESC prefix → no terminal interpretation).
+        let raw = "\x1b[32m/home/user/boilerplates\x1b[0m";
+        assert_eq!(
+            strip_control_chars(raw),
+            "[32m/home/user/boilerplates[0m"
+        );
+    }
+
+    #[test]
+    fn test_strip_control_chars_passthrough_clean_path() {
+        let path = "/home/user/boilerplates";
+        assert_eq!(strip_control_chars(path), path);
+    }
+
+    #[test]
+    fn test_strip_control_chars_removes_bare_esc() {
+        let raw = "\x1b";
+        assert_eq!(strip_control_chars(raw), "");
     }
 
     #[test]

--- a/src/gibo.rs
+++ b/src/gibo.rs
@@ -329,10 +329,7 @@ mod tests {
         // removes the ESC byte, leaving the non-control remnant "[32m...[0m" harmless
         // (no ESC prefix → no terminal interpretation).
         let raw = "\x1b[32m/home/user/boilerplates\x1b[0m";
-        assert_eq!(
-            strip_control_chars(raw),
-            "[32m/home/user/boilerplates[0m"
-        );
+        assert_eq!(strip_control_chars(raw), "[32m/home/user/boilerplates[0m");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`gibo_root()` in `src/gibo.rs` returned the raw stdout from `gibo root` with only `.trim()` applied. The path value was then embedded directly in error messages via `pin_boilerplates()`, creating an ANSI injection path if `gibo` emits colour-coded output.

`gi.rs` already guards HTTP error bodies through `sanitize_error_body()`. This PR brings the same control-character filtering to the subprocess path string.

## Changes

- `src/gibo.rs`: add `strip_control_chars()` that filters `char::is_control()` characters
- `src/gibo.rs`: apply `strip_control_chars()` to the trimmed stdout in `gibo_root()`
- `src/gibo.rs`: add three unit tests covering ANSI-prefixed paths, clean paths, and bare ESC

## Verification

- `cargo fmt --all -- --check`: clean
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test`: 104 tests passed (including the 3 new `strip_control_chars` tests); intermittent subprocess-contention failures in `gi_command`/`test_parse_text` are pre-existing and unrelated to this change

## Trade-offs

- Only the ESC byte (0x1b) is removed; the non-control remnant `[32m…[0m` remains in the string. Without the ESC prefix the sequence is inert to terminal interpreters, so the path in error messages is sanitised against injection while remaining legible.
- Stripping control chars from a filesystem path is safe: valid POSIX paths do not contain control characters.
