### PR TITLE
fix: kill and wait child process when pid_t conversion fails

### DIFF
--- a/src/gibo.rs
+++ b/src/gibo.rs
@@ -107,8 +107,16 @@ fn run_command_with_timeout(
         .stderr(Stdio::piped())
         .process_group(0)
         .spawn()?;
-    let process_group_id = libc::pid_t::try_from(child.id())
-        .map_err(|_| std::io::Error::other(format!("{program} pid is out of range")))?;
+    let process_group_id = match libc::pid_t::try_from(child.id()) {
+        Ok(pid) => pid,
+        Err(_) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(std::io::Error::other(format!(
+                "{program} pid is out of range"
+            )));
+        }
+    };
 
     let stdout = child
         .stdout


### PR DESCRIPTION
## Summary

When `run_command_with_timeout` spawns a child process and then `libc::pid_t::try_from(child.id())` fails, the `?` operator causes an early return that drops `child` without killing or waiting for it. `std::process::Child` does not kill or wait on drop, so the child becomes an orphan process and a zombie until the parent exits.

This change replaces the `?`-propagation with an explicit `match` that kills and waits the child before returning the error.

## Changes

- `src/gibo.rs`: `run_command_with_timeout` — kill and wait the child process on pid conversion failure instead of early-returning via `?`

## Verification

- `cargo build` — OK
- `cargo fmt --check` — OK
- `cargo clippy` — no warnings
- `cargo test` — all 8 tests pass