### PR TITLE
fix(ci): keep octocov main runs from canceling coverage baselines

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Stop canceling octocov runs for default-branch pushes.
- Keep pull request octocov runs canceling superseded commits.
- Preserve fresher default-branch coverage reports for octocov diff baselines.

## Change

`.github/workflows/octocov.yml` now makes `concurrency.cancel-in-progress` conditional on `pull_request` events. Push runs on `main` share the same concurrency group but no longer cancel each other before the coverage report can update the datastore.

## Verification

- `actionlint .github/workflows/octocov.yml`
- `typos`
- `cargo fmt --all -- --check`
- `go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh`
- `cargo check`
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo build`
- `git diff --check`
