### PR TITLE
fix(ci): require DOWNSTREAM_RELEASE_PAT before dispatching downstream workflows

### DIFF
--- a/.github/workflows/prepare-downstream-release.yml
+++ b/.github/workflows/prepare-downstream-release.yml
@@ -27,6 +27,15 @@ jobs:
           - gitignore-in/homebrew-gitignore-in
           - gitignore-in/gh-action
     steps:
+      - name: Require downstream release token
+        env:
+          DOWNSTREAM_RELEASE_PAT: ${{ secrets.DOWNSTREAM_RELEASE_PAT }}
+        run: |
+          if [ -z "${DOWNSTREAM_RELEASE_PAT}" ]; then
+            echo "DOWNSTREAM_RELEASE_PAT secret is required to dispatch downstream release workflows." >&2
+            exit 1
+          fi
+
       - name: Resolve released version
         id: version
         env:

--- a/.github/workflows/rehearse-downstream-on-main.yml
+++ b/.github/workflows/rehearse-downstream-on-main.yml
@@ -50,6 +50,15 @@ jobs:
           - gitignore-in/homebrew-gitignore-in
           - gitignore-in/gh-action
     steps:
+      - name: Require downstream release token
+        env:
+          DOWNSTREAM_RELEASE_PAT: ${{ secrets.DOWNSTREAM_RELEASE_PAT }}
+        run: |
+          if [ -z "${DOWNSTREAM_RELEASE_PAT}" ]; then
+            echo "DOWNSTREAM_RELEASE_PAT secret is required to dispatch downstream rehearsal workflows." >&2
+            exit 1
+          fi
+
       - name: Dispatch downstream rehearsal
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
         with:


### PR DESCRIPTION
## Summary

- Add an explicit `DOWNSTREAM_RELEASE_PAT` presence check at the start of the `dispatch` job in `prepare-downstream-release.yml` and `rehearse-downstream-on-main.yml`.
- Mirrors the pattern already used in `prepare-release-pr.yml` for `RELEASE_PAT`.

## Change

`prepare-release-pr.yml` already validates that `RELEASE_PAT` is set before using it, producing a clear error message if it is missing. The two downstream-dispatch workflows lacked an equivalent guard: if `DOWNSTREAM_RELEASE_PAT` is unset, `peter-evans/repository-dispatch` fails with an opaque authentication error and the downstream repository never receives the event.

This change adds a `Require downstream release token` step as the first step in the `dispatch` job of each affected workflow. The step checks `[ -z "${DOWNSTREAM_RELEASE_PAT}" ]` and exits with a descriptive error message, consistent with the existing pattern.

## Verification

- `cargo fmt --all -- --check` — OK
- `cargo clippy --all-targets --all-features -- -D warnings` — OK (no warnings)
- `cargo test` — 5/5 passed
- `actionlint .github/workflows/prepare-downstream-release.yml .github/workflows/rehearse-downstream-on-main.yml` — 0 findings
