### PR TITLE
docs: document double-hash encoding contract in parser, build, and restore

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -19,6 +19,11 @@ pub(crate) fn build(script: GitIgnoreIn) -> std::io::Result<String> {
     for statement in script.content {
         match statement {
             GitIgnoreStatement::Comment(Comment::Content(c)) => {
+                // `c` already contains the leading `#` (e.g. `# my comment`).
+                // Prefixing `# ` produces `# # my comment` in the output
+                // .gitignore.  This double-hash is the encoding contract that
+                // restore() relies on to distinguish user comments from
+                // section headers (`# gibo dump …` / `# gi …`).
                 result.push_str(&format!("# {c}\n"));
             }
             GitIgnoreStatement::Meaningless(Meaningless::Content(m)) => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -34,6 +34,11 @@ pub fn parse_line(text: &str) -> GitIgnoreStatement {
     if let Some(stripped) = text.strip_prefix("echo ") {
         return GitIgnoreStatement::Echo(Echo::Content(remove_shell_quote(stripped)));
     }
+    // Store the full line including the leading `#` so that build() can
+    // distinguish comments from section headers by prefixing `# ` again,
+    // producing the `# # comment` double-hash encoding in the output
+    // .gitignore.  restore() detects that `# #` prefix to recover the
+    // original comment line.
     if text.starts_with('#') {
         return GitIgnoreStatement::Comment(Comment::Content(text.to_string()));
     }

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -68,6 +68,10 @@ where
     }
 }
 
+// Decode the double-hash encoding that build() writes for comment lines.
+// build() stores comments as `Comment::Content("# original")` and emits
+// `# # original` (prefixing `# ` once more).  Stripping the outer `# `
+// here recovers the original `# original` line from .gitignore.in.
 fn restore_comment_line(line: &str) -> Option<String> {
     line.strip_prefix("# #")
         .map(|comment| format!("#{comment}"))


### PR DESCRIPTION
## Summary

`build()` encodes comment lines from `.gitignore.in` using a double-hash
convention: a comment like `# foo` is stored in `Comment::Content("# foo")`
(full line including `#`) and then emitted as `# # foo` in the output
`.gitignore`.  `restore()` detects the `# #` prefix and strips the outer
`# ` to recover the original `# foo` line.

This three-file contract (parser → build → restore) was implicit and
undocumented, making it easy to accidentally break the round-trip when
modifying any of the three modules.

## Changes

Added inline comments in the three modules that participate in the
double-hash encoding protocol:

- `src/parser.rs` — explains why the full `# comment` line (including `#`)
  is stored verbatim in `Comment::Content`
- `src/build.rs` — explains that `format\!("# {c}\n")` intentionally creates
  `# # comment` as the encoding for user comments
- `src/restore.rs` — explains the decode step: stripping `# #` recovers the
  original comment from `.gitignore.in`

No logic changes; comments only.

## Verification

`cargo clippy` and `cargo test` (unit + integration) pass without
modification.

## Trade-offs

Inline comments keep the documentation co-located with the contract, so a
future reader modifying any one module sees the protocol immediately.  The
alternative (a separate design doc) would be easier to miss and harder to
keep in sync.