### PR TITLE
Remove unreachable empty-overlap guard in infer_from_candidates

### DIFF
--- a/src/infer.rs
+++ b/src/infer.rs
@@ -95,10 +95,6 @@ pub(crate) fn infer_from_candidates(
         choose_best_candidate(candidates, &remaining, min_overlap)
     {
         let candidate = &candidates[best_index];
-        if overlap.is_empty() {
-            break;
-        }
-
         selected_commands.push(candidate.command.clone());
         for line in overlap {
             remaining.remove(&line);


### PR DESCRIPTION
## Summary

Remove an unreachable dead-code guard in `infer_from_candidates`.

`choose_best_candidate` returns `Some((index, overlap))` only when `overlap` is non-empty:
- Candidates with `candidate.lines.is_empty()` are skipped unconditionally.
- Candidates where `overlap.len() < min_overlap` (default: 2) are skipped — this excludes `overlap.len() == 0`.
- Candidates where `overlap.len() * 2 < candidate.lines.len()` are skipped — if overlap is 0 and candidate has ≥1 line this condition also fires.

So the `if overlap.is_empty() { break; }` block following the `while let Some(...)` binding can never be reached. Removing it eliminates misleading dead code without any behavior change.

## Change

- `src/infer.rs`: Remove the 4-line unreachable guard block.

## Verification

- `cargo clippy` — no warnings
- `cargo test` — 108 tests pass (100 unit + 8 integration)
