### PR TITLE
Strip server-generated metadata from rulesets JSON

### DIFF
--- a/.github/rulesets/default-branch-baseline.json
+++ b/.github/rulesets/default-branch-baseline.json
@@ -1,12 +1,4 @@
 {
-    "_links": {
-        "html": {
-            "href": "https://github.com/gitignore-in/gitignore-in/rules/13625124"
-        },
-        "self": {
-            "href": "https://api.github.com/repos/gitignore-in/gitignore-in/rulesets/13625124"
-        }
-    },
     "bypass_actors": [],
     "conditions": {
         "ref_name": {
@@ -16,12 +8,8 @@
             ]
         }
     },
-    "created_at": "2026-03-08T11:22:06.752+09:00",
-    "current_user_can_bypass": "never",
     "enforcement": "active",
-    "id": 13625124,
     "name": "default-branch-baseline",
-    "node_id": "RRS_lACqUmVwb3NpdG9yec4m46WLzgDP5yQ",
     "rules": [
         {
             "parameters": {
@@ -85,6 +73,5 @@
     ],
     "source": "gitignore-in/gitignore-in",
     "source_type": "Repository",
-    "target": "branch",
-    "updated_at": "2026-06-16T02:51:01.010+09:00"
+    "target": "branch"
 }


### PR DESCRIPTION
## Summary

Remove server-generated API metadata from the committed ruleset JSON.

The file `.github/rulesets/default-branch-baseline.json` was captured from a GitHub API GET response, which includes read-only server-generated fields that have no place in a source-controlled as-code document:

| Field | Why it doesn't belong |
|---|---|
| `_links` | API-internal URLs with a hardcoded server-assigned ruleset ID |
| `id` | Server-assigned numeric ID; cannot be specified on create/update |
| `node_id` | GraphQL opaque ID; server-generated, not user-settable |
| `current_user_can_bypass` | Varies per authenticated user; a committed value is misleading |
| `created_at` / `updated_at` | Drift on every UI change; committed value is immediately stale |

After removing these fields, the file retains only the declarative configuration values: `name`, `enforcement`, `bypass_actors`, `conditions`, `rules`, `source`, `source_type`, `target`.

## Change

- `.github/rulesets/default-branch-baseline.json`: Remove `_links`, `id`, `node_id`, `current_user_can_bypass`, `created_at`, `updated_at` (14 lines deleted).

## Verification

No code changes — CI is unaffected. The removed fields are not referenced anywhere in the repository.
