### PR TITLE
Move configure-security-settings.sh to scripts/admin/ to separate admin tools from CI helpers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: stable
-      - run: go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/*.sh
+      - run: go run mvdan.cc/sh/v3/cmd/shfmt@v3.13.1 -d scripts/
 
   lint:
     name: Lint

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,18 @@
+# scripts/
+
+## CI helpers
+
+Called from GitHub Actions workflows. Work with the default `GITHUB_TOKEN`.
+
+| Script | Caller workflow |
+| --- | --- |
+| `check-release-version.sh` | `binary-release.yml`, `cratesio-publish.yml` |
+| `set-version.sh` | `prepare-release-pr.yml` |
+
+## Admin tools (`admin/`)
+
+Require manual execution with elevated credentials. **Not for CI.**
+
+| Script | Required scope |
+| --- | --- |
+| `admin/configure-security-settings.sh` | `admin:repo` OAuth scope |

--- a/scripts/admin/configure-security-settings.sh
+++ b/scripts/admin/configure-security-settings.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Enable GitHub Secret Scanning and Push Protection for this repository.
 #
-# Usage: ./scripts/configure-security-settings.sh [--dry-run]
+# Usage: ./scripts/admin/configure-security-settings.sh [--dry-run]
 #
 # Requires: gh CLI authenticated with a token that has admin:repo scope.
 # Idempotent: exits 0 if settings are already in the desired state.


### PR DESCRIPTION
## Summary

`scripts/` previously mixed two kinds of scripts with very different permission requirements:

- **CI helpers** (`set-version.sh`, `check-release-version.sh`) — called by GitHub Actions using the default `GITHUB_TOKEN`.
- **Admin tool** (`configure-security-settings.sh`) — requires a personal `admin:repo` OAuth token; must be run manually.

There was no directory-level or documented distinction between them, making it easy to overlook the elevated-privilege requirement when browsing `scripts/`.

## Changes

- Move `configure-security-settings.sh` → `scripts/admin/configure-security-settings.sh`.
- Add `scripts/README.md` documenting the two categories and their caller/permission expectations.
- Update `test.yml` shell-format check from `scripts/*.sh` to `scripts/` so the moved script remains covered by CI.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings`: no new findings.
- `typos scripts/`: no spelling issues.
- CI workflows that reference `set-version.sh` and `check-release-version.sh` are unchanged.
- No workflow calls `configure-security-settings.sh`; the move is non-breaking for CI.

## Trade-offs

- `scripts/admin/` currently holds one file. If more admin tools are added later, the directory pays for itself; if not, it is a small but harmless subdirectory.
