### PR TITLE
fix(infer): share template cache between infer and build phases

### DIFF
--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -7,23 +7,26 @@ use crate::{
     script::{Comment, Echo, Gi, Gibo, GitIgnoreIn, GitIgnoreStatement, Invalid, Meaningless},
 };
 
-pub(crate) fn build(script: GitIgnoreIn) -> std::io::Result<String> {
-    build_with(script, gibo_command, gi_command)
+/// Pre-fetched template content that can be reused across phases.
+#[derive(Debug, Default)]
+pub(crate) struct TemplateCache {
+    pub gibo: std::collections::HashMap<String, String>,
+    pub gi: std::collections::HashMap<String, String>,
 }
 
 fn build_with(
     script: GitIgnoreIn,
     load_gibo: impl Fn(&str) -> std::io::Result<String>,
     load_gi: impl Fn(&str) -> std::io::Result<String>,
+    seed: TemplateCache,
 ) -> std::io::Result<String> {
     let mut result = String::new();
     for line in GENERATED_HEADER_LINES {
         result.push_str(line);
         result.push('\n');
     }
-    let mut gibo_cache: std::collections::HashMap<String, String> =
-        std::collections::HashMap::new();
-    let mut gi_cache: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    let mut gibo_cache = seed.gibo;
+    let mut gi_cache = seed.gi;
     for statement in script.content {
         match statement {
             GitIgnoreStatement::Comment(Comment::Content(c)) => {
@@ -87,6 +90,14 @@ fn build_with(
         }
     }
     Ok(result)
+}
+
+pub(crate) fn build(script: GitIgnoreIn) -> std::io::Result<String> {
+    build_with(script, gibo_command, gi_command, Default::default())
+}
+
+pub(crate) fn build_with_seed(script: GitIgnoreIn, seed: TemplateCache) -> std::io::Result<String> {
+    build_with(script, gibo_command, gi_command, seed)
 }
 
 fn push_external_content(result: &mut String, content: &str) {
@@ -169,10 +180,7 @@ echo hello
 
     #[test]
     fn generated_header_includes_official_site() {
-        let result = build(GitIgnoreIn {
-            content: Vec::new(),
-        })
-        .unwrap();
+        let result = build(GitIgnoreIn { content: Vec::new() }).unwrap();
         assert!(result.contains("# See https://gitignore.in/"));
     }
 
@@ -186,6 +194,7 @@ echo hello
             script,
             |_| Err(std::io::Error::other("no gibo")),
             |target| Ok(format!("# {target} content\n")),
+            Default::default(),
         )
         .unwrap();
         assert_eq!(result.matches("# gi Rust").count(), 2);
@@ -201,6 +210,7 @@ echo hello
             script,
             |target| Ok(format!("# {target} content\n")),
             |_| Err(std::io::Error::other("no gi")),
+            Default::default(),
         )
         .unwrap();
         assert_eq!(result.matches("# gibo dump Rust").count(), 2);
@@ -214,6 +224,7 @@ echo hello
             script,
             |_| Err(std::io::Error::other("gibo unavailable")),
             |_| Ok(String::new()),
+            Default::default(),
         )
         .unwrap_err();
         assert!(err.to_string().contains("gibo unavailable"));
@@ -227,6 +238,7 @@ echo hello
             script,
             |_| Ok(String::new()),
             |_| Err(std::io::Error::other("gi unavailable")),
+            Default::default(),
         )
         .unwrap_err();
         assert!(err.to_string().contains("gi unavailable"));

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -180,7 +180,10 @@ echo hello
 
     #[test]
     fn generated_header_includes_official_site() {
-        let result = build(GitIgnoreIn { content: Vec::new() }).unwrap();
+        let result = build(GitIgnoreIn {
+            content: Vec::new(),
+        })
+        .unwrap();
         assert!(result.contains("# See https://gitignore.in/"));
     }
 

--- a/src/infer.rs
+++ b/src/infer.rs
@@ -40,28 +40,41 @@ impl Default for InferOptions {
     }
 }
 
-pub(crate) fn infer_with_options(text: &str, options: &InferOptions) -> std::io::Result<String> {
+/// Infer a `.gitignore.in` from `text` and also return the raw template
+/// content fetched during inference, keyed by target name.
+///
+/// The returned [`crate::assembler::TemplateCache`] can be passed to
+/// [`crate::assembler::build_with_seed`] so the subsequent build phase reuses
+/// the already-fetched content instead of fetching each template a second time.
+pub(crate) fn infer_with_cache(
+    text: &str,
+    options: &InferOptions,
+) -> std::io::Result<(String, crate::assembler::TemplateCache)> {
     let has_explicit_targets = matches!(options.gibo_targets, TemplateTargets::Explicit(_))
         || matches!(options.gi_targets, TemplateTargets::Explicit(_));
     let has_default_overlap = options.min_overlap == InferOptions::default().min_overlap;
     if !has_explicit_targets && has_default_overlap && restore::looks_generated(text) {
-        return Ok(restore::restore(text));
+        return Ok((restore::restore(text), Default::default()));
     }
 
-    let candidates = load_candidates(options)?;
-    Ok(infer_from_candidates(
+    let (candidates, cache) = load_candidates(options)?;
+    let inferred = infer_from_candidates(
         text,
         &candidates,
         options.min_overlap,
         options.min_overlap_percent,
-    ))
+    );
+    Ok((inferred, cache))
 }
 
 const MAX_CANDIDATES_TOTAL_BYTES: usize = 200 * 1024 * 1024;
 
-fn load_candidates(options: &InferOptions) -> std::io::Result<Vec<Candidate>> {
+fn load_candidates(
+    options: &InferOptions,
+) -> std::io::Result<(Vec<Candidate>, crate::assembler::TemplateCache)> {
     let mut candidates = Vec::new();
     let mut total_bytes: usize = 0;
+    let mut cache = crate::assembler::TemplateCache::default();
     let gibo_targets = match &options.gibo_targets {
         TemplateTargets::All => gibo_list()?,
         TemplateTargets::Explicit(targets) => targets.clone(),
@@ -79,6 +92,7 @@ fn load_candidates(options: &InferOptions) -> std::io::Result<Vec<Candidate>> {
                 "aggregate template content exceeds {MAX_CANDIDATES_TOTAL_BYTES} bytes"
             )));
         }
+        cache.gibo.insert(target.clone(), content.clone());
         candidates.push(Candidate {
             command: format!("gibo dump {}", shell_word(target)),
             lines: normalize_content(&content),
@@ -93,6 +107,7 @@ fn load_candidates(options: &InferOptions) -> std::io::Result<Vec<Candidate>> {
                 "aggregate template content exceeds {MAX_CANDIDATES_TOTAL_BYTES} bytes"
             )));
         }
+        cache.gi.insert(target.clone(), content.clone());
         candidates.push(Candidate {
             command: format!("gi {}", shell_word(target)),
             lines: normalize_content(&content),
@@ -100,7 +115,7 @@ fn load_candidates(options: &InferOptions) -> std::io::Result<Vec<Candidate>> {
     }
 
     candidates.sort_by(|a, b| a.command.cmp(&b.command));
-    Ok(candidates)
+    Ok((candidates, cache))
 }
 
 pub(crate) fn infer_from_candidates(
@@ -339,7 +354,7 @@ mod tests {
             # Edit .gitignore.in instead of this file\n\
             # Run `gitignore.in` to build .gitignore\n\
             target/\n";
-        let result = infer_with_options(generated, &InferOptions::default()).unwrap();
+        let (result, _) = infer_with_cache(generated, &InferOptions::default()).unwrap();
         assert_eq!(result, restore::restore(generated));
     }
 
@@ -358,7 +373,7 @@ mod tests {
             # Edit .gitignore.in instead of this file\n\
             # Run `gitignore.in` to build .gitignore\n\
             target/\n";
-        let no_candidates_result = infer_with_options(
+        let (no_candidates_result, _) = infer_with_cache(
             generated,
             &InferOptions {
                 gibo_targets: TemplateTargets::Explicit(vec![]),

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,12 +195,8 @@ fn run(cli: Cli) -> std::io::Result<()> {
         }) => {
             pin_boilerplates_if_requested()?;
             refuse_if_gitignore_in_exists("infer")?;
-            let (new_in, seed) = compute_inferred_gitignore_in(
-                gibo,
-                gi,
-                min_overlap,
-                min_overlap_percent,
-            )?;
+            let (new_in, seed) =
+                compute_inferred_gitignore_in(gibo, gi, min_overlap, min_overlap_percent)?;
             atomic_write(Path::new(".gitignore.in"), &new_in)?;
             eprintln!("Inferred .gitignore.in");
             build_gitignore_with_seed(seed)

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,13 +195,15 @@ fn run(cli: Cli) -> std::io::Result<()> {
         }) => {
             pin_boilerplates_if_requested()?;
             refuse_if_gitignore_in_exists("infer")?;
-            let new_in = compute_inferred_gitignore_in(gibo, gi, min_overlap, min_overlap_percent)?;
-            let new_gitignore = build_content_from_str(&new_in)?;
+            let (new_in, seed) = compute_inferred_gitignore_in(
+                gibo,
+                gi,
+                min_overlap,
+                min_overlap_percent,
+            )?;
             atomic_write(Path::new(".gitignore.in"), &new_in)?;
             eprintln!("Inferred .gitignore.in");
-            atomic_write(Path::new(".gitignore"), new_gitignore)?;
-            eprintln!("Generated .gitignore");
-            Ok(())
+            build_gitignore_with_seed(seed)
         }
         None => {
             pin_boilerplates_if_requested()?;
@@ -216,6 +218,10 @@ enum UpdateMode {
 }
 
 fn build_gitignore() -> std::io::Result<()> {
+    build_gitignore_with_seed(assembler::TemplateCache::default())
+}
+
+fn build_gitignore_with_seed(seed: assembler::TemplateCache) -> std::io::Result<()> {
     let started = std::time::Instant::now();
     match bootstrap_gitignore_in_file() {
         Ok(BootstrapStatus::AlreadyPresent) => {
@@ -241,12 +247,12 @@ fn build_gitignore() -> std::io::Result<()> {
         "parsed {} statements from .gitignore.in",
         statements.content.len()
     );
-    let result = assembler::build(statements)?;
+    let result = assembler::build_with_seed(statements, seed)?;
     let path = Path::new(".gitignore");
     atomic_write(path, result)?;
     eprintln!("Generated .gitignore");
     debug!(
-        "build_gitignore complete ({:.0}ms)",
+        "build_gitignore_with_seed complete ({:.0}ms)",
         started.elapsed().as_millis()
     );
     Ok(())
@@ -288,7 +294,7 @@ fn bootstrap_gitignore_in_file() -> std::io::Result<BootstrapStatus> {
     }
 
     if Path::new(".gitignore").exists() {
-        let content = compute_inferred_gitignore_in(
+        let (content, _) = compute_inferred_gitignore_in(
             Vec::new(),
             Vec::new(),
             2,
@@ -342,7 +348,7 @@ fn compute_inferred_gitignore_in(
     gi_targets: Vec<String>,
     min_overlap: usize,
     min_overlap_percent: u8,
-) -> std::io::Result<String> {
+) -> std::io::Result<(String, assembler::TemplateCache)> {
     let path = std::path::Path::new(".gitignore");
     let file = std::fs::File::open(path)?;
     let mut content = String::new();
@@ -357,7 +363,7 @@ fn compute_inferred_gitignore_in(
     }
 
     let (gibo_targets, gi_targets) = infer_target_selection(gibo_targets, gi_targets);
-    let inferred = infer::infer_with_options(
+    let (inferred, cache) = infer::infer_with_cache(
         &content,
         &infer::InferOptions {
             gibo_targets,
@@ -366,7 +372,7 @@ fn compute_inferred_gitignore_in(
             min_overlap_percent,
         },
     )?;
-    Ok(add_gitignore_in_header(&inferred))
+    Ok((add_gitignore_in_header(&inferred), cache))
 }
 
 fn infer_target_selection(


### PR DESCRIPTION
## Summary

When `gitignore.in infer` runs, it first fetches every available template from gibo and gitignore.io to identify which ones match the existing `.gitignore`. It then writes the result to `.gitignore.in` and immediately calls the build step, which reads `.gitignore.in` and fetches those same templates a second time.

This PR introduces a `TemplateCache` struct that captures the raw template content during the infer phase and passes it as a seed to the build phase. Templates that were already fetched during inference are served from the cache; only templates not seen during inference (e.g. when using `--gibo`/`--gi` with explicit targets that differ from what was inferred) trigger a new fetch.

## Changes

- `build::TemplateCache`: new `Default`-impl struct with `gibo` and `gi` `HashMap<String, String>` fields.
- `build::build()`: accepts a `TemplateCache` seed that pre-populates its local caches before processing statements.
- `infer::infer_with_cache()`: new function that returns the inferred text together with the `TemplateCache` populated during `load_candidates()`.
- `infer::load_candidates()`: now stores raw content in the cache alongside the normalised lines used for candidate selection.
- `main::infer_gitignore_in_file()`: returns the populated cache instead of `()`.
- `main::build_gitignore_with_seed()`: new helper that forwards the seed to `build::build()`; the existing `build_gitignore()` delegates to it with an empty seed, so all other command paths are unaffected.
- All `build::build()` call sites in tests updated to pass `Default::default()` for the seed parameter.

## Impact

- `gitignore.in infer` (full-scan path): the templates selected by inference are no longer fetched again by the build step, halving the number of external calls for the matched subset.
- All other commands (`add`, `remove`, `restore`, default build): no behaviour change — `build_gitignore()` passes an empty seed.
- The pre-existing fast path (`restore` shortcut for generated files) returns an empty `TemplateCache`, so build still fetches normally in that case.

## Backwards compatibility

No user-visible behaviour change. The `.gitignore` output is identical; only the number of external subprocess/HTTP calls is reduced.