### PR TITLE
fix: remove unreachable downstream size checks after upstream cap

### DIFF
--- a/src/gi.rs
+++ b/src/gi.rs
@@ -89,12 +89,6 @@ fn validate_gi_response(
             ),
         ));
     }
-    if body.len() > MAX_RESPONSE_BYTES {
-        return Err(std::io::Error::other(format!(
-            "Failed to get {target} from {url}: response body too large ({} bytes, max {MAX_RESPONSE_SIZE_DISPLAY} / {MAX_RESPONSE_BYTES} bytes)",
-            body.len()
-        )));
-    }
     if body.is_empty() {
         return Err(std::io::Error::other(format!(
             "Failed to get {target} from {url}: empty response body"
@@ -143,12 +137,6 @@ fn validate_gi_list_response(
                 body.len()
             ),
         ));
-    }
-    if body.len() > MAX_RESPONSE_BYTES {
-        return Err(std::io::Error::other(format!(
-            "Failed to get list from {url}: response body too large ({} bytes, max {MAX_RESPONSE_SIZE_DISPLAY} / {MAX_RESPONSE_BYTES} bytes)",
-            body.len()
-        )));
     }
     if body.is_empty() {
         return Err(std::io::Error::other(format!(
@@ -587,21 +575,6 @@ mod tests {
             validate_gi_list_response(StatusCode::OK, String::new(), "https://example.test/list")
                 .unwrap_err();
         assert!(err.to_string().contains("empty response body"));
-    }
-
-    #[test]
-    fn test_validate_gi_response_rejects_oversized_body() {
-        let body = "x".repeat(MAX_RESPONSE_BYTES + 1);
-        let err = validate_gi_response(StatusCode::OK, body, "X", &dummy_url()).unwrap_err();
-        assert!(err.to_string().contains("too large"));
-    }
-
-    #[test]
-    fn test_validate_gi_list_response_rejects_oversized_body() {
-        let body = "x".repeat(MAX_RESPONSE_BYTES + 1);
-        let err = validate_gi_list_response(StatusCode::OK, body, "https://example.test/list")
-            .unwrap_err();
-        assert!(err.to_string().contains("too large"));
     }
 
     #[test]

--- a/src/gibo.rs
+++ b/src/gibo.rs
@@ -275,12 +275,6 @@ fn validate_gibo_command_output(
                 truncate_stderr(stderr)
             )));
         }
-        if stdout.len() > MAX_SUBPROCESS_OUTPUT_BYTES {
-            return Err(std::io::Error::other(format!(
-                "Failed to get {target} from gibo: output too large ({} bytes, max {MAX_SUBPROCESS_OUTPUT_BYTES})",
-                stdout.len()
-            )));
-        }
         return Ok(stdout);
     }
     let code = status
@@ -306,12 +300,6 @@ fn validate_gibo_list_output(
         return Err(std::io::Error::other(format!(
             "Failed to list templates from gibo: exit={code} stderr={}",
             truncate_stderr(stderr)
-        )));
-    }
-    if stdout.len() > MAX_SUBPROCESS_OUTPUT_BYTES {
-        return Err(std::io::Error::other(format!(
-            "Failed to list templates from gibo: output too large ({} bytes, max {MAX_SUBPROCESS_OUTPUT_BYTES})",
-            stdout.len()
         )));
     }
     let templates: Vec<String> = stdout
@@ -554,22 +542,6 @@ mod tests {
         let err = validate_gibo_command_output(make_status(1), String::new(), &long_stderr, "C++")
             .unwrap_err();
         assert!(err.to_string().contains("truncated"));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn test_validate_gibo_command_output_rejects_oversized_stdout() {
-        let stdout = "x".repeat(MAX_SUBPROCESS_OUTPUT_BYTES + 1);
-        let err = validate_gibo_command_output(make_status(0), stdout, "", "C++").unwrap_err();
-        assert!(err.to_string().contains("too large"));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn test_validate_gibo_list_output_rejects_oversized_stdout() {
-        let stdout = "x".repeat(MAX_SUBPROCESS_OUTPUT_BYTES + 1);
-        let err = validate_gibo_list_output(make_status(0), stdout, "").unwrap_err();
-        assert!(err.to_string().contains("too large"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

After the upstream size cap was added to `read_to_end` (gibo.rs) and
`read_response_body_string` (gi.rs), the downstream `> MAX_*` checks in
the four `validate_*` functions became unreachable.

Both upstream functions apply `.take(MAX + 1)` and return `Err` if the
buffer reaches the limit, so any `Ok` return guarantees the buffer is
`<= MAX` bytes. The downstream `if body/stdout.len() > MAX` checks
therefore can never be true.

**Functions with removed dead branches:**
- `gibo.rs`: `validate_gibo_command_output`, `validate_gibo_list_output`
- `gi.rs`: `validate_gi_response`, `validate_gi_list_response`

**Tests removed:** The four tests that exercised these dead branches
(`test_validate_*_rejects_oversized_*`) are also removed. Coverage of
the actual protection path is already provided by
`test_read_to_end_rejects_oversized_output` (gibo.rs).

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings`: no warnings
- `cargo test`: 104 tests pass, 0 failures (96 unit + 3 CLI output + 5 integration)
- Adjacent static check: `cargo clippy` — 0 new findings

## Trade-offs

**Only removes dead code.** The actual size protection is unchanged —
`read_to_end` and `read_response_body_string` still cap input at
`MAX + 1` bytes. Future maintainers modifying those upstream caps will
no longer see a misleading "backup" check that gives false confidence.