### PR TITLE
Handle consecutive separators in restore without emitting echo

### DIFF
--- a/src/restore.rs
+++ b/src/restore.rs
@@ -28,6 +28,10 @@ pub(crate) fn restore(text: &str) -> String {
                 continue;
             }
 
+            if section_head == SEPARATOR {
+                continue;
+            }
+
             result.push(format!("echo {}", shell_quote(section_head)));
 
             continue;
@@ -200,6 +204,17 @@ plain-entry
         );
         let restored = restore(text);
         assert_eq!(restored, "gi 'Visual Studio'\n");
+    }
+
+    #[test]
+    fn consecutive_separators_produce_no_echo() {
+        // A manually-edited .gitignore may contain two adjacent separators.
+        // The second separator must be skipped, not emitted as `echo '# ---...---'`.
+        let text = concat!(
+            "# -----------------------------------------------------------------------------\n",
+            "# -----------------------------------------------------------------------------\n",
+        );
+        assert_eq!(restore(text), "\n");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When `restore` encounters a separator line (`SEPARATOR`), it reads the next line
as the section header. If the `.gitignore` was manually edited and now contains
two consecutive separators, the second separator is consumed as the section header.
Because it matches neither the `# gibo dump ` nor the `# gi ` prefix, it falls
through to the echo fallback and is emitted as `echo '# ---...---'` in the
restored `.gitignore.in`. On the next `build` run this produces a literal
`# ---...---` line as gitignore content rather than a comment or blank line.

## Change

In `restore.rs`, add an early-return check after consuming the section header:
if it equals `SEPARATOR`, skip it silently (no echo output) and continue the
outer loop. This prevents the separator value from appearing as echo content.

A new unit test `consecutive_separators_produce_no_echo` covers this boundary case.

## Trade-offs

- This fix targets the minimal scope: only the echo of SEPARATOR itself is
  suppressed. Content that follows a double-separator in the malformed file is
  processed as if the separators were absent (treated as plain text lines).
- The normal `build → edit → restore` flow is unaffected; this path is only
  reachable when `.gitignore` is edited directly.
