### PR TITLE
fix: prefer retriable error kind when all catalog providers fail

### DIFF
--- a/src/edit.rs
+++ b/src/edit.rs
@@ -60,7 +60,23 @@ impl Catalog {
         }
 
         if catalog.entries.is_empty() && !errors.is_empty() {
-            let kind = errors[0].1.kind();
+            let kind = errors
+                .iter()
+                .map(|(_, e)| e.kind())
+                .find(|&k| {
+                    matches!(
+                        k,
+                        io::ErrorKind::BrokenPipe
+                            | io::ErrorKind::ConnectionAborted
+                            | io::ErrorKind::ConnectionRefused
+                            | io::ErrorKind::ConnectionReset
+                            | io::ErrorKind::Interrupted
+                            | io::ErrorKind::NotConnected
+                            | io::ErrorKind::TimedOut
+                            | io::ErrorKind::UnexpectedEof
+                    )
+                })
+                .unwrap_or_else(|| errors[0].1.kind());
             let details = errors
                 .into_iter()
                 .map(|(provider, error)| format!("{provider}: {error}"))
@@ -552,7 +568,10 @@ mod tests {
         )
         .expect_err("catalog load should fail when no provider can list templates");
 
-        assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
+        // gi's NotConnected (retriable network failure) takes priority over
+        // gibo's NotFound (permanent missing-binary error), so callers that
+        // inspect the exit code get EXIT_TEMPORARY_FAILURE (75) and can retry.
+        assert_eq!(error.kind(), std::io::ErrorKind::NotConnected);
         assert!(error.to_string().contains("gibo: missing gibo"));
         assert!(error.to_string().contains("gitignore.io: offline"));
     }


### PR DESCRIPTION
## Summary

When both catalog providers (gibo and gitignore.io) fail, `Catalog::load_from` selects the `ErrorKind` of `errors[0]` (always gibo) to represent the combined failure. If gibo is missing (`NotFound`) but gitignore.io is unreachable (`NotConnected`), callers receive exit code 2 (usage error) instead of 75 (temporary failure), so retry logic triggered on exit code 75 never fires.

## Change

Replace the fixed `errors[0].1.kind()` selection with an iterator scan that returns the first retriable kind (`NotConnected`, `TimedOut`, `BrokenPipe`, etc.) when present, falling back to `errors[0]` only when no retriable kind exists.

Update the existing `load_from_errors_when_all_providers_fail` test to assert `NotConnected` (the corrected priority behaviour). The error message still contains both provider details, so human-readable diagnosis is unchanged.

## Verification

- `cargo test load_from` — all 3 unit tests pass
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test` — full suite passes
