### PR TITLE
fix: required `happy` check swallows failures via `continue-on-error`

### DIFF
--- a/.github/workflows/happy.yml
+++ b/.github/workflows/happy.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     name: happy
-    continue-on-error: true
     steps:
       - uses: kitsuyui/happy-commit@b8724714862e1b643122b8f233b3aaca26b9825d # v0.9
         with:


### PR DESCRIPTION
## Finding

The `happy` job in `.github/workflows/happy.yml` is set to `continue-on-error: true`, so the `happy` check registered as a required status check does not actually block failures.

## Why

This workflow serves as a CI gate for PRs, but the job-level setting swallows failures, so even when `kitsuyui/happy-commit` detects a problem the workflow can still end up successful. The required-check name exists without providing a real block, degrading CI reliability.

## Impact

Even when happy-commit detects an anomaly, the required check can appear to pass, weakening the PR safety valve. CI may let through changes it should have stopped, misleading review and merge decisions.
