### PR TITLE
fix(ci): add timeout and concurrency to Dependabot check workflow

### DIFF
--- a/.github/workflows/check-dependabot-security-updates.yml
+++ b/.github/workflows/check-dependabot-security-updates.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 0 * * 1'  # every Monday
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   administration: read
@@ -12,6 +16,7 @@ permissions:
 jobs:
   check-dependabot-security-updates:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Check Dependabot security updates


### PR DESCRIPTION
## Summary
- add the repository-standard top-level concurrency block to `check-dependabot-security-updates.yml`
- add a 10-minute job timeout so a hung GitHub API call does not inherit the default six-hour Actions timeout

## Why
This workflow was added after the repository standardized concurrency and timeout guards across its other GitHub Actions workflows. Without these guards, scheduled, retried, or manually dispatched runs can overlap and a stalled `gh api` call can hold a runner far longer than intended.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/check-dependabot-security-updates.yml")'`
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`
