### PR TITLE
fix(ci): reuse octocov cache after Cargo.lock updates

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -35,15 +35,9 @@ jobs:
       - name: git-restore-mtime
         uses: chetan/git-restore-mtime-action@d186aca54f8760da4dec55313195e51ed3ebb0b3 # v2.3
 
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          cache-workspace-crates: true
 
       - uses: gitignore-in/install-gibo@9e7dba9e59f184b41f542669b0864687a6f69b45 # v0.1.0
 


### PR DESCRIPTION
## Summary
- replace the hand-rolled `actions/cache` step in `octocov.yml` with `Swatinem/rust-cache`
- cache workspace crates so coverage builds can reuse compiled artifacts after `Cargo.lock` changes
- keep the existing `cargo llvm-cov` coverage command and octocov reporting flow unchanged

## Why
A `push` run on `main` for commit `bcb038afc720fad13e4777606e2f0bed1b5dbfda` on July 26, 2026 timed out in the `coverage` step after 45 minutes, while the workflow currently restores cache entries only from an exact `Cargo.lock` hash. That makes dependency bumps fall back to a cold coverage build on `main`.

Using the same Rust cache action as the rest of the repository gives the workflow a stable Rust-specific cache strategy instead of an exact one-off cache key, which is the smallest repository-local change that improves reuse without changing the observable coverage/reporting behavior.

## Verification
- `cargo test`
- `cargo llvm-cov --lcov --output-path /tmp/gitignore-in-coverage.lcov`
